### PR TITLE
Caseinsensitive

### DIFF
--- a/pdir/api.py
+++ b/pdir/api.py
@@ -36,9 +36,6 @@ class PrettyDir(object):
     def __getitem__(self, index):
         return self.attrs[index].name
 
-    def s(self, term):
-        return self.search(term)
-
     def search(self, term, case_sensitive=False):
         """Search for names that match some pattern.
 
@@ -57,6 +54,8 @@ class PrettyDir(object):
             term = term.lower()
             self.attrs = [attr for attr in self.attrs if term in attr.name.lower()]
         return self
+
+    s = search
 
     def __inspect_category(self, source):
         for name, attribute in source.items():

--- a/pdir/api.py
+++ b/pdir/api.py
@@ -39,17 +39,23 @@ class PrettyDir(object):
     def s(self, term):
         return self.search(term)
 
-    def search(self, term):
+    def search(self, term, case_sensitive=False):
         """Search for names that match some pattern.
 
         Args:
             term: String used to match names. A name is returned if it matches
-            the whole search term.
+              the whole search term.
+            case_sensitive: Boolean to match case or not, default is False
+              (case insensitive)
 
         Return:
             A PrettyDir object with matched names.
         """
-        self.attrs = [attr for attr in self.attrs if term in attr.name]
+        if case_sensitive:
+            self.attrs = [attr for attr in self.attrs if term in attr.name]
+        else:
+            term = term.lower()
+            self.attrs = [attr for attr in self.attrs if term in attr.name.lower()]
         return self
 
     def __inspect_category(self, source):

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -23,13 +23,18 @@ def test_search_with_argument():
         pass
 
     result, result2 = pdir(T).s('attr'), pdir(T).search('attr')
-    assert repr(result) == '\n'.join([
+    result3, result4 = pdir(T).s('Attr'), pdir(T).search('Attr')
+    expected = '\n'.join([
         '\x1b[0;33mattribute access:\x1b[0;m', (
             '    \x1b[0;36m__delattr__\x1b[0;m\x1b[1;30m, '
             '\x1b[0;m\x1b[0;36m__getattribute__\x1b[0;m\x1b[1;30m, '
             '\x1b[0;m\x1b[0;36m__setattr__\x1b[0;m')])
-    assert repr(result2) == '\n'.join([
-        '\x1b[0;33mattribute access:\x1b[0;m', (
-            '    \x1b[0;36m__delattr__\x1b[0;m\x1b[1;30m, '
-            '\x1b[0;m\x1b[0;36m__getattribute__\x1b[0;m\x1b[1;30m, '
-            '\x1b[0;m\x1b[0;36m__setattr__\x1b[0;m')])
+    assert repr(result) == expected
+    assert repr(result2) == expected
+    assert repr(result3) == expected
+    assert repr(result4) == expected
+
+    # Case sensitive
+    result5, result6 = pdir(T).s('Attr', True), pdir(T).search('Attr', True)
+    assert repr(result5) == ''
+    assert repr(result6) == ''


### PR DESCRIPTION
Change the default search to be case insensitive, with the option for case sensitive search. 

The direct alias from s -> search allows help(pdir.s) to work exactly like help(pdir.search) without copy/pasting the docstring. 