### PR TITLE
Format methods as functions

### DIFF
--- a/pdir/api.py
+++ b/pdir/api.py
@@ -80,6 +80,8 @@ class PrettyDir(object):
             return CLASS
         elif inspect.isfunction(attribute):
             return FUNCTION
+        elif inspect.ismethod(attribute):
+            return FUNCTION
         elif inspect.isbuiltin(attribute):
             return FUNCTION
         elif inspect.ismethoddescriptor(attribute):  # list.append


### PR DESCRIPTION
Would it make sense to consider methods as functions in the output? When I use pdir() on a class, all of the class methods are considered "other", and I'd like to be able to read their docstrings in the output.