### PR TITLE
Fix Readme rendering on PyPI

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,5 +1,5 @@
 pdir2: Pretty dir() printing with joy🍺
-======================================
+=======================================
 
 |Build Status| |Supported Python versions| |PyPI Version|
 


### PR DESCRIPTION
PyPI requires that the long_description passes its strict reST check without warnings.
To make sure it passes before releases, you can run

    python setup.py check --restructuredtext --strict