### PR TITLE
Only require colorama on Windows

### DIFF
--- a/pdir/api.py
+++ b/pdir/api.py
@@ -1,15 +1,16 @@
 from __future__ import print_function
 
 import inspect
+import platform
 from itertools import groupby
 from sys import _getframe
-
-from colorama import init
 
 from .constants import *
 from .format import format_category
 
-init()  # To support Windows.
+if platform.system() == 'Windows':
+    from colorama import init
+    init()  # To support Windows.
 
 
 class PrettyDir(object):

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
         'pdir',
     ],
     install_requires=[
-        'colorama',
+        'colorama;platform_system=="Windows"',
         'enum34;python_version<"3.4"',
     ],
     include_package_data=True,


### PR DESCRIPTION
Colorama is not needed on other operating systems.
I could only test this change on Linux. Can someone please verify that Windows works the same as before with this change?