### PR TITLE
Separate static method from descript category

### DIFF
--- a/pdir/api.py
+++ b/pdir/api.py
@@ -197,7 +197,8 @@ class PrettyDir(object):
             # act as functions, let's treat them as functions.
             return AttrType(AttrCategory.FUNCTION)
         elif isinstance(attr, staticmethod):
-            return AttrType(AttrCategory.DESCRIPTOR, AttrCategory.STATIC_METHOD)
+            return AttrType(AttrCategory.DESCRIPTOR, AttrCategory.STATIC_METHOD,
+                            AttrCategory.FUNCTION)
         elif is_descriptor(attr):
             # Maybe add getsetdescriptor memberdescriptor in the future.
             return AttrType(AttrCategory.DESCRIPTOR, AttrCategory.PROPERTY)

--- a/pdir/api.py
+++ b/pdir/api.py
@@ -196,6 +196,8 @@ class PrettyDir(object):
             # Technically, method_descriptor is descriptor, but since they
             # act as functions, let's treat them as functions.
             return AttrType(AttrCategory.FUNCTION)
+        elif isinstance(attr, staticmethod):
+            return AttrType(AttrCategory.DESCRIPTOR, AttrCategory.STATIC_METHOD)
         elif is_descriptor(attr):
             # Maybe add getsetdescriptor memberdescriptor in the future.
             return AttrType(AttrCategory.DESCRIPTOR, AttrCategory.PROPERTY)

--- a/pdir/constants.py
+++ b/pdir/constants.py
@@ -59,6 +59,7 @@ class AttrCategory(IntEnum):
     ATTRIBUTE_ACCESS = Incrementer.auto()
     DESCRIPTOR = Incrementer.auto()
     DESCRIPTOR_CLASS = Incrementer.auto()
+    STATIC_METHOD = Incrementer.auto()
     CLASS_CUSTOMIZATION = Incrementer.auto()
     CONTAINER = Incrementer.auto()
     COUROUTINE = Incrementer.auto()

--- a/pdir/format.py
+++ b/pdir/format.py
@@ -68,6 +68,7 @@ CATEGORY_FORMAT_TABLE = {
     AttrCategory.ATTRIBUTE_ACCESS: AttributeFormatterType.SINGLE_LINE,
     AttrCategory.DESCRIPTOR: AttributeFormatterType.DESCRIPTOR,
     AttrCategory.DESCRIPTOR_CLASS: AttributeFormatterType.SINGLE_LINE,
+    AttrCategory.STATIC_METHOD: AttributeFormatterType.DESCRIPTOR,
     AttrCategory.CLASS_CUSTOMIZATION: AttributeFormatterType.SINGLE_LINE,
     AttrCategory.CONTAINER: AttributeFormatterType.SINGLE_LINE,
     AttrCategory.COUROUTINE: AttributeFormatterType.SINGLE_LINE,


### PR DESCRIPTION
Separate @staticmethod from descript category (according to #38)
```
>>> pdir(pdir)
abstract class:
    __subclasshook__
attribute access:
    __delattr__, __dir__, __getattribute__, __setattr__
container:
    __getitem__, __len__
object customization:
    __format__, __hash__, __init__, __new__, __repr__, __sizeof__, __str__
pickle:
    __reduce__, __reduce_ex__
property:
    repl_type
rich comparison:
    __eq__, __ge__, __gt__, __le__, __lt__, __ne__
special attribute:
    __class__, __dict__, __doc__, __module__, __weakref__
descriptor:
    methods: @property with getter, Returns all methods of the inspected object.
    own: @property with getter, Returns attributes that are not inhterited from parent classes.
    properties: @property with getter, Returns all properties of the inspected object.
    public: @property with getter, Returns public attributes of the inspected object.
    repr_str: @property with getter
static method:
    get_category: class staticmethod with getter, staticmethod(function) -> method
function:
    _PrettyDir__getattr_wrapper: A wrapper around getattr(), handling some exceptions.
    _PrettyDir__inspect_category: 
    index: 
    s: Searches for names that match some pattern.
    search: Searches for names that match some pattern.

```
And @staticmethod will be in the `methods` property:
```
>>> pdir(pdir).methods
abstract class:
    __subclasshook__
attribute access:
    __delattr__, __dir__, __getattribute__, __setattr__
container:
    __getitem__, __len__
object customization:
    __format__, __hash__, __init__, __new__, __repr__, __sizeof__, __str__
pickle:
    __reduce__, __reduce_ex__
rich comparison:
    __eq__, __ge__, __gt__, __le__, __lt__, __ne__
static method:
    get_category: class staticmethod with getter, staticmethod(function) -> method
function:
    _PrettyDir__getattr_wrapper: A wrapper around getattr(), handling some exceptions.
    _PrettyDir__inspect_category: 
    index: 
    s: Searches for names that match some pattern.
    search: Searches for names that match some pattern.
```