### PR TITLE
Fix some deprecations

### DIFF
--- a/pdir/attr_category.py
+++ b/pdir/attr_category.py
@@ -1,4 +1,4 @@
-import collections
+import collections.abc
 import functools
 import inspect
 from enum import IntEnum, auto
@@ -66,10 +66,10 @@ def category_match(
 # Names that belong to different categories in different conditions.
 ATTR_MAP_CONDITIONAL = {
     '__reversed__': lambda obj: (AttrCategory.ITER, AttrCategory.FUNCTION)
-    if isinstance(obj, collections.Iterator)
+    if isinstance(obj, collections.abc.Iterator)
     else (AttrCategory.CONTAINER, AttrCategory.FUNCTION),
     '__iter__': lambda obj: (AttrCategory.ITER, AttrCategory.FUNCTION)
-    if isinstance(obj, collections.Iterator)
+    if isinstance(obj, collections.abc.Iterator)
     else (AttrCategory.CONTAINER, AttrCategory.FUNCTION),
     '__name__': lambda obj: (AttrCategory.MODULE_ATTRIBUTE, AttrCategory.PROPERTY)
     if inspect.ismodule(obj)

--- a/pdir/format.py
+++ b/pdir/format.py
@@ -8,7 +8,7 @@ from .attr_category import AttrCategory
 from .configuration import attribute_color, category_color, comma, slot_tag, doc_color
 from . import api  # noqa: F401, '.api' imported but unused
 from typing import List
-from collections import Iterable
+from collections.abc import Iterable
 
 
 def format_pattrs(pattrs: List['api.PrettyAttribute']) -> str:

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -43,7 +43,7 @@ def test_default_env_without_config(clean):
 
 def test_set_env_without_config(clean):
     os.environ['PDIR2_CONFIG_FILE'] = 'aaa'
-    with pytest.raises(OSError, message='Config file not exist: aaa'):
+    with pytest.raises(OSError, match='Config file not exist: aaa'):
         import pdir
 
         pdir()
@@ -93,7 +93,7 @@ def test_empty_config(clean):
 
 def test_invalid_config_1(clean):
     shutil.copyfile('tests/data/error_config_1.ini', clean)
-    with pytest.raises(ValueError, message='Invalid key: doc-color1'):
+    with pytest.raises(ValueError, match='Invalid key: doc-color1'):
         import pdir
 
         pdir()
@@ -101,7 +101,7 @@ def test_invalid_config_1(clean):
 
 def test_invalid_config_2(clean):
     shutil.copyfile('tests/data/error_config_2.ini', clean)
-    with pytest.raises(ValueError, message='Invalid color value: 42'):
+    with pytest.raises(ValueError, match='Invalid color value: 42'):
         import pdir
 
         pdir()


### PR DESCRIPTION
> DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated, and in 3.8 it will stop working