### PR TITLE
Fix CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9 ]
-        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        python-version: [3.7, 3.8, 3.9]
+        os: [ubuntu-latest, macOS-latest, windows-latest]
 
     steps:
       - uses: actions/checkout@v1
@@ -31,10 +31,9 @@ jobs:
       - name: Install dependencies
         run: pdm install
         # On Windows, interactive test doesn't work, so exclude it.
-      - name: Run tests Windows
-        run: pdm run tox -epy37,py38,py39
-        if: runner.os == 'Windows'
-        shell: bash
       - name: Run tests
         run: pdm run tox
+
+      - name: Interactive tests
         if: runner.os != 'Windows'
+        run: pdm run tox -eextra

--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist =py37,py38,py39,lint,extra,mypy
 python =
     3.7: py37
     3.8: py38
-    3.9: py39,lint,extra,mypy
+    3.9: py39,lint,mypy
 
 [testenv]
 deps=
@@ -13,7 +13,7 @@ deps=
     colorama
     pandas
 commands=
-    py.test -s -vv {posargs} {toxinidir}/tests/
+    pytest -s -vv {posargs} {toxinidir}/tests/
 
 [testenv:extra]
 deps=
@@ -41,7 +41,7 @@ deps =
     pytest>=4.0.0
     mypy
     pytest-mypy
-commands = py.test -s --mypy {toxinidir}/tests/ --ignore={toxinidir}/tests/interactive_test.py
+commands = pytest -s --mypy {toxinidir}/tests/ --ignore={toxinidir}/tests/interactive_test.py
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Previously, the Windows CI will run against ALL python versions on each `python-version` value.

This PR fixes the CI so that:

Linux: run tests & interactive tests on py37 and py38, run tests & lint & mypy on py39
Windows: run tests on py37, py38, py39 and run lint & mypy on py39