### PR TITLE
Set empty doc if testing for __doc__ attribute throws an exception.

### DIFF
--- a/pdir/api.py
+++ b/pdir/api.py
@@ -203,7 +203,12 @@ class PrettyAttribute:
                 doc_list.append(doc.split('\n', 1)[0])
             return ', '.join(doc_list)
 
-        if hasattr(attr, '__doc__'):
+        try:
+            hasattr_doc = hasattr(attr, '__doc__')
+        except:
+            hasattr_doc = False
+
+        if hasattr_doc:
             doc = inspect.getdoc(attr)
             return doc.split('\n', 1)[0] if doc else ''  # default doc is None
         return ''

--- a/tests/test_buggy_attrs.py
+++ b/tests/test_buggy_attrs.py
@@ -115,3 +115,27 @@ def test_override_dir():
     pattrs = pdir(inst).pattrs
     assert ('foo' in pdir(inst)) == ('foo' in dir(inst))
     assert ('foo' in [pattr.name for pattr in pattrs]) == ('foo' in dir(inst))
+
+
+def test_get_attribute_fail():
+    """"Tests if get_online_doc returns '' when __doc__ access throws an exception."""
+
+    class DocAttributeFail:
+        """Fails when __doc__ atribute is accessed."""
+        def __getattribute__(self, name):
+            if name == '__doc__':
+                raise Exception('failed successfully')
+            else:
+                return super().__getattribute__(name)
+
+    class DocFailContainer:
+        """Holds attributes that fail when __doc__ is accessed."""
+        dac1 = DocAttributeFail()
+        def __init__(self):
+            self.dac2 = DocAttributeFail()
+
+    for pattr in pdir(DocFailContainer()).pattrs:
+        if pattr.name in ['dac1', 'dac2']:
+            assert pattr.get_oneline_doc() == ''
+
+


### PR DESCRIPTION
I was getting an error when I tried to run pdir on classes from a jar-file wrapped with jpype:

```
~/.local/lib/python3.9/site-packages/pdir/api.py in get_oneline_doc(self)
    205             return ', '.join(doc_list)
    206 
--> 207         if hasattr(attr, '__doc__'):
    208             doc = inspect.getdoc(attr)
    209             return doc.split('\n', 1)[0] if doc else ''  # default doc is None

~/.local/lib/python3.9/site-packages/jpype/_jclass.py in _jclassDoc(cls)
    162     if not hasattr(cls, "__javadoc__"):
    163         jde = JClass("org.jpype.javadoc.JavadocExtractor")()
--> 164         jd = jde.getDocumentation(cls)
    165         if jd is not None:
    166             setattr(cls, "__javadoc__", jd)

SystemError: Fail in conversion
```
In this fix I simply set an empty doc if an Exception occurs calling `hasattr`.