### PR TITLE
Fix _FORMATTER with missing categories

### DIFF
--- a/pdir/format.py
+++ b/pdir/format.py
@@ -65,6 +65,7 @@ _multiline_with_doc = _AttributeGroupFormatter(
 )
 
 _FORMATTER = {
+    AttrCategory.SLOT: _single_line,
     AttrCategory.FUNCTION: _multiline_with_doc,
     AttrCategory.CLASS: _multiline_with_doc,
     AttrCategory.EXCEPTION: _multiline_with_doc,
@@ -89,4 +90,6 @@ _FORMATTER = {
     AttrCategory.COPY: _single_line,
     AttrCategory.PICKLE: _single_line,
     AttrCategory.ABSTRACT_CLASS: _single_line,
+    AttrCategory.PATTERN_MATCHING: _single_line,
+    AttrCategory.TYPING: _single_line,
 }

--- a/pdir/format.py
+++ b/pdir/format.py
@@ -2,13 +2,13 @@
 Defines how attr is organized and displayed.
 """
 from collections import namedtuple
-from itertools import groupby
-
-from .attr_category import AttrCategory
-from .configuration import attribute_color, category_color, comma, slot_tag, doc_color
-from . import api  # noqa: F401, '.api' imported but unused
-from typing import List
 from collections.abc import Iterable
+from itertools import groupby
+from typing import List
+
+from . import api  # noqa: F401, '.api' imported but unused
+from .attr_category import AttrCategory
+from .configuration import attribute_color, category_color, comma, doc_color, slot_tag
 
 
 def format_pattrs(pattrs: List['api.PrettyAttribute']) -> str:

--- a/tests/test_pdir_format.py
+++ b/tests/test_pdir_format.py
@@ -2,6 +2,13 @@ import sys
 
 import pdir
 import pytest
+from pdir.attr_category import AttrCategory
+from pdir.format import _FORMATTER
+
+
+def test_formatter_integrity():
+    for ac in AttrCategory:
+        assert ac in _FORMATTER
 
 
 def test_pdir_module():

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -25,7 +25,7 @@ def clean():
             del modules[module]
         except KeyError:
             pass
-    
+
     DEFAULT_CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.pdir2config')
     yield DEFAULT_CONFIG_FILE
     if 'PDIR2_CONFIG_FILE' in os.environ:


### PR DESCRIPTION
Seems like `_FORMATTER` aims more for readability, so instead of a default value, I added a test case to make sure it's properly synced with `AttrCategory`.