### PR TITLE
Support disable color and switch off color when stdout is not a TTY

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # - name: Cache pypackages
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: __pypackages__
-      #     key: pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
-      #     restore-keys: |
-      #       pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
+      - name: Cache pypackages
+        uses: actions/cache@v2
+        with:
+          path: __pypackages__
+          key: pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
+          restore-keys: |
+            pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
 
-      # - name: Cache tox pypackages
-      #   uses: actions/cache@v2
-      #   with:
-      #     path: .tox/**/__pypackages__
-      #     key: tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
-      #     restore-keys: |
-      #       tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
+      - name: Cache tox pypackages
+        uses: actions/cache@v2
+        with:
+          path: .tox/**/__pypackages__
+          key: tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
+          restore-keys: |
+            tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Install dependencies
         run: pdm install -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,21 +28,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Cache pypackages
-        uses: actions/cache@v2
-        with:
-          path: __pypackages__
-          key: pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
-          restore-keys: |
-            pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
+      # - name: Cache pypackages
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: __pypackages__
+      #     key: pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
+      #     restore-keys: |
+      #       pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
 
-      - name: Cache tox pypackages
-        uses: actions/cache@v2
-        with:
-          path: .tox/**/__pypackages__
-          key: tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
-          restore-keys: |
-            tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
+      # - name: Cache tox pypackages
+      #   uses: actions/cache@v2
+      #   with:
+      #     path: .tox/**/__pypackages__
+      #     key: tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
+      #     restore-keys: |
+      #       tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
 
       - name: Install dependencies
         run: pdm install -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,6 @@ jobs:
           restore-keys: |
             pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
 
-      - name: Cache tox pypackages
-        uses: actions/cache@v2
-        with:
-          path: .tox/**/__pypackages__
-          key: tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
-          restore-keys: |
-            tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
-
       - name: Install dependencies
         run: pdm install -v
         # On Windows, interactive test doesn't work, so exclude it.

--- a/pdir/api.py
+++ b/pdir/api.py
@@ -6,7 +6,6 @@ Convention:
 
 from __future__ import print_function
 
-import inspect
 import platform
 from sys import _getframe
 from typing import Any, List, Optional, Tuple

--- a/pdir/color.py
+++ b/pdir/color.py
@@ -1,5 +1,5 @@
 from ._internal_utils import is_bpython
-from typing import Protocol
+from typing_extensions import Protocol
 
 
 class _Renderable(Protocol):

--- a/pdir/color.py
+++ b/pdir/color.py
@@ -6,7 +6,7 @@ class _Renderable(Protocol):
     def wrap_text(self, text: str) -> str:
         pass
 
-    def __eq__(self, other: '_Renderable') -> bool:
+    def __eq__(self, other: object) -> bool:
         pass
 
 
@@ -25,7 +25,12 @@ class _Color(_Renderable):
         else:
             return '\033[1m' + colored_text
 
-    def __eq__(self, other: '_Color') -> bool:  # type: ignore
+    def __eq__(self, other: object) -> bool:  # type: ignore
+        # __eq__ should work with any objects.
+        # https://mypy.readthedocs.io/en/stable/common_issues.html#incompatible-overrides
+        if not isinstance(other, _Color):
+            return False
+
         return self.color_code == other.color_code
 
     def __repr__(self):
@@ -36,7 +41,7 @@ class _ColorDisabled(_Renderable):
     def wrap_text(self, text: str) -> str:
         return text
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if isinstance(other, _ColorDisabled):
             return True
         return False

--- a/pdir/color.py
+++ b/pdir/color.py
@@ -2,7 +2,7 @@ from ._internal_utils import is_bpython
 from typing import Protocol
 
 
-class _Render(Protocol):
+class _Renderable(Protocol):
     def wrap_text(self, text: str) -> str:
         pass
 
@@ -10,7 +10,7 @@ class _Render(Protocol):
         pass
 
 
-class _Color(_Render):
+class _Color(_Renderable):
     def __init__(self, color_code: int, bright: bool = False) -> None:
         self.color_code = str(color_code)
         self.intensity = '1' if bright else '0'
@@ -32,7 +32,7 @@ class _Color(_Render):
         return '\033[%sm%s\033[0m' % (self.color_code, 'color')
 
 
-class _ColorDisabled:
+class _ColorDisabled(_Renderable):
     def wrap_text(self, text: str) -> str:
         return text
 

--- a/pdir/color.py
+++ b/pdir/color.py
@@ -6,7 +6,7 @@ class _Renderable(Protocol):
     def wrap_text(self, text: str) -> str:
         pass
 
-    def __eq__(self, other: '_Render') -> bool:
+    def __eq__(self, other: '_Renderable') -> bool:
         pass
 
 

--- a/pdir/color.py
+++ b/pdir/color.py
@@ -23,6 +23,16 @@ class _Color:
         return '\033[%sm%s\033[0m' % (self.color_code, 'color')
 
 
+class _ColorDisabled:
+    def wrap_text(self, text: str) -> str:
+        return text
+
+    def __eq__(self, other):
+        if isinstance(other, _ColorDisabled):
+            return True
+        return False
+
+
 COLORS = {
     'black': _Color(30),
     'bright black': _Color(30, True),
@@ -42,3 +52,4 @@ COLORS = {
     'white': _Color(37),
     'bright white': _Color(37, True),
 }
+COLOR_DISABLED = _ColorDisabled()

--- a/pdir/color.py
+++ b/pdir/color.py
@@ -1,7 +1,16 @@
 from ._internal_utils import is_bpython
+from typing import Protocol
 
 
-class _Color:
+class _Render(Protocol):
+    def wrap_text(self, text: str) -> str:
+        pass
+
+    def __eq__(self, other: '_Render') -> bool:
+        pass
+
+
+class _Color(_Render):
     def __init__(self, color_code: int, bright: bool = False) -> None:
         self.color_code = str(color_code)
         self.intensity = '1' if bright else '0'

--- a/pdir/configuration.py
+++ b/pdir/configuration.py
@@ -135,6 +135,3 @@ else:
     category_color = attribute_color = doc_color = COLOR_DISABLED
     comma = ', '
     slot_tag = '(slotted)'
-
-
-print("init!")

--- a/pdir/configuration.py
+++ b/pdir/configuration.py
@@ -13,6 +13,12 @@ _DEFAULT_CONFIG_FILE = expanduser('~/.pdir2config')
 _DEFAULT = 'global'
 _UNIFORM_COLOR = 'uniform-color'
 _COLORFUL_OUTPUT = 'enable-colorful-output'
+TRUTHY_TERMS = frozenset (
+    {
+
+        "True", "Y", "1", "true"
+    }
+)
 VALID_CONFIG_KEYS = frozenset(
     {
         'category-color',
@@ -102,12 +108,10 @@ class Configuration:
 _cfg = Configuration()
 
 
-def should_enable_colorful_output():
-    """
-    environ > config_file
-    """
+def should_enable_colorful_output() -> bool:
+    """When set, environ suppresses config file."""
     environ_set = os.getenv("PDIR2_NOCOLOR")
-    if environ_set and environ_set in ["True", "Y", "1", "true"]:
+    if environ_set and environ_set in TRUTHY_TERMS:
         return False
 
     if (
@@ -118,9 +122,8 @@ def should_enable_colorful_output():
     return _cfg.enable_colorful_output == "True"
 
 
-enable_colorful_output = should_enable_colorful_output()
 
-if enable_colorful_output:
+if should_enable_colorful_output():
     if _cfg.uniform_color:
         category_color = attribute_color = doc_color = _cfg.uniform_color
         comma = _cfg.uniform_color.wrap_text(', ')

--- a/pdir/configuration.py
+++ b/pdir/configuration.py
@@ -87,16 +87,15 @@ class Configuration:
             return
         user_config_dict = dict(self._configparser.items(_DEFAULT))
 
-        self._enable_colorful_output = user_config_dict.get(_COLORFUL_OUTPUT)
-
-        # UNIFORM_COLOR suppresses other settings.
-        if _UNIFORM_COLOR in user_config_dict:
-            self._uniform_color = COLORS[user_config_dict[_UNIFORM_COLOR]]
-            return
-
         for item, color in user_config_dict.items():
-            if item in [_COLORFUL_OUTPUT, _UNIFORM_COLOR]:
+            if item == _COLORFUL_OUTPUT:
+                self._enable_colorful_output = user_config_dict.get(_COLORFUL_OUTPUT)
                 continue
+            # UNIFORM_COLOR suppresses other settings.
+            if item == _UNIFORM_COLOR:
+                self._uniform_color = COLORS[user_config_dict[_UNIFORM_COLOR]]
+                return
+            # then the color settings
             if item not in VALID_CONFIG_KEYS:
                 raise ValueError('Invalid key: %s' % item)
             if color not in set(COLORS.keys()):
@@ -120,7 +119,6 @@ def should_enable_colorful_output() -> bool:
         return sys.stdout.isatty()
 
     return _cfg.enable_colorful_output == "True"
-
 
 
 if should_enable_colorful_output():

--- a/pdir/configuration.py
+++ b/pdir/configuration.py
@@ -13,12 +13,7 @@ _DEFAULT_CONFIG_FILE = expanduser('~/.pdir2config')
 _DEFAULT = 'global'
 _UNIFORM_COLOR = 'uniform-color'
 _COLORFUL_OUTPUT = 'enable-colorful-output'
-TRUTHY_TERMS = frozenset (
-    {
-
-        "True", "Y", "1", "true"
-    }
-)
+TRUTHY_TERMS = frozenset({'True', 'Y', '1', 'true'})
 VALID_CONFIG_KEYS = frozenset(
     {
         'category-color',

--- a/pdir/configuration.py
+++ b/pdir/configuration.py
@@ -12,7 +12,7 @@ from .color import COLORS, COLOR_DISABLED
 _DEFAULT_CONFIG_FILE = expanduser('~/.pdir2config')
 _DEFAULT = 'global'
 _UNIFORM_COLOR = 'uniform-color'
-_COLORFUL_OUTPUT = 'colorful-output'
+_COLORFUL_OUTPUT = 'enable-colorful-output'
 VALID_CONFIG_KEYS = frozenset(
     {
         'category-color',
@@ -27,7 +27,7 @@ VALID_CONFIG_KEYS = frozenset(
 class Configuration:
 
     _uniform_color = None
-    _colorful_output = None
+    _enable_colorful_output = None
     _category_color = COLORS['yellow']
     _attribute_color = COLORS['cyan']
     _comma_color = COLORS['grey']
@@ -39,8 +39,8 @@ class Configuration:
         self._load()
 
     @property
-    def colorful_output(self):
-        return self._colorful_output
+    def enable_colorful_output(self):
+        return self._enable_colorful_output
 
     @property
     def uniform_color(self):
@@ -81,7 +81,7 @@ class Configuration:
             return
         user_config_dict = dict(self._configparser.items(_DEFAULT))
 
-        self._colorful_output = user_config_dict.get(_COLORFUL_OUTPUT)
+        self._enable_colorful_output = user_config_dict.get(_COLORFUL_OUTPUT)
 
         # UNIFORM_COLOR suppresses other settings.
         if _UNIFORM_COLOR in user_config_dict:
@@ -102,7 +102,7 @@ class Configuration:
 _cfg = Configuration()
 
 
-def should_colorful_output():
+def should_enable_colorful_output():
     """
     environ > config_file
     """
@@ -111,16 +111,16 @@ def should_colorful_output():
         return False
 
     if (
-        _cfg.colorful_output is None or _cfg.colorful_output == "auto"
+        _cfg.enable_colorful_output is None or _cfg.enable_colorful_output == "auto"
     ):  # Not set, default to "auto"
         return sys.stdout.isatty()
 
-    return _cfg.colorful_output == "True"
+    return _cfg.enable_colorful_output == "True"
 
 
-colorful_output = should_colorful_output()
+enable_colorful_output = should_enable_colorful_output()
 
-if colorful_output:
+if enable_colorful_output:
     if _cfg.uniform_color:
         category_color = attribute_color = doc_color = _cfg.uniform_color
         comma = _cfg.uniform_color.wrap_text(', ')

--- a/pdir/configuration.py
+++ b/pdir/configuration.py
@@ -12,9 +12,9 @@ from .color import COLORS, COLOR_DISABLED
 _DEFAULT_CONFIG_FILE = expanduser('~/.pdir2config')
 _DEFAULT = 'global'
 _UNIFORM_COLOR = 'uniform-color'
+_COLORFUL_OUTPUT = 'colorful-output'
 VALID_CONFIG_KEYS = frozenset(
     {
-        _UNIFORM_COLOR,
         'category-color',
         'attribute-color',
         'comma-color',
@@ -27,6 +27,7 @@ VALID_CONFIG_KEYS = frozenset(
 class Configuration:
 
     _uniform_color = None
+    _colorful_output = None
     _category_color = COLORS['yellow']
     _attribute_color = COLORS['cyan']
     _comma_color = COLORS['grey']
@@ -80,7 +81,7 @@ class Configuration:
             return
         user_config_dict = dict(self._configparser.items(_DEFAULT))
 
-        self._colorful_output = user_config_dict.get("colorful_output")
+        self._colorful_output = user_config_dict.get(_COLORFUL_OUTPUT)
 
         # UNIFORM_COLOR suppresses other settings.
         if _UNIFORM_COLOR in user_config_dict:
@@ -88,6 +89,8 @@ class Configuration:
             return
 
         for item, color in user_config_dict.items():
+            if item in [_COLORFUL_OUTPUT, _UNIFORM_COLOR]:
+                continue
             if item not in VALID_CONFIG_KEYS:
                 raise ValueError('Invalid key: %s' % item)
             if color not in set(COLORS.keys()):

--- a/pdir/configuration.py
+++ b/pdir/configuration.py
@@ -38,8 +38,8 @@ class Configuration:
         self._load()
 
     @property
-    def disable_color(self):
-        return self._disable_color
+    def colorful_output(self):
+        return self._colorful_output
 
     @property
     def uniform_color(self):
@@ -80,7 +80,7 @@ class Configuration:
             return
         user_config_dict = dict(self._configparser.items(_DEFAULT))
 
-        self._disable_color = user_config_dict.get("disable_color")
+        self._colorful_output = user_config_dict.get("colorful_output")
 
         # UNIFORM_COLOR suppresses other settings.
         if _UNIFORM_COLOR in user_config_dict:
@@ -101,16 +101,18 @@ _cfg = Configuration()
 
 def should_colorful_output():
     """
-    config_file > environ > is_tty
+    environ > config_file
     """
-    if _cfg.disable_color:
-        return False
-
     environ_set = os.getenv("PDIR2_NOCOLOR")
     if environ_set and environ_set in ["True", "Y", "1"]:
         return False
 
-    return sys.stdout.isatty()
+    if (
+        _cfg.colorful_output is None or _cfg.colorful_output == "auto"
+    ):  # Not set, default to "auto"
+        return sys.stdout.isatty()
+
+    return _cfg.colorful_output == "True"
 
 
 colorful_output = should_colorful_output()

--- a/pdir/configuration.py
+++ b/pdir/configuration.py
@@ -107,7 +107,7 @@ def should_colorful_output():
     environ > config_file
     """
     environ_set = os.getenv("PDIR2_NOCOLOR")
-    if environ_set and environ_set in ["True", "Y", "1"]:
+    if environ_set and environ_set in ["True", "Y", "1", "true"]:
         return False
 
     if (
@@ -135,3 +135,6 @@ else:
     category_color = attribute_color = doc_color = COLOR_DISABLED
     comma = ', '
     slot_tag = '(slotted)'
+
+
+print("init!")

--- a/pdm.lock
+++ b/pdm.lock
@@ -222,13 +222,16 @@ dependencies = [
 
 [[package]]
 name = "pandas"
-version = "1.1.5"
-requires_python = ">=3.6.1"
+version = "1.3.5"
+requires_python = ">=3.7.1"
 summary = "Powerful data structures for data analysis, time series, and statistics"
 dependencies = [
-    "numpy>=1.15.4",
+    "numpy>=1.17.3; platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\"",
+    "numpy>=1.19.2; platform_machine == \"aarch64\" and python_version < \"3.10\"",
+    "numpy>=1.20.0; platform_machine == \"arm64\" and python_version < \"3.10\"",
+    "numpy>=1.21.0; python_version >= \"3.10\"",
     "python-dateutil>=2.7.3",
-    "pytz>=2017.2",
+    "pytz>=2017.3",
 ]
 
 [[package]]

--- a/pdm.lock
+++ b/pdm.lock
@@ -62,8 +62,8 @@ summary = "Python package for providing Mozilla's CA Bundle."
 
 [[package]]
 name = "charset-normalizer"
-version = "2.0.12"
-requires_python = ">=3.5.0"
+version = "2.1.0"
+requires_python = ">=3.6.0"
 summary = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 
 [[package]]
@@ -377,12 +377,12 @@ summary = "PyXDG contains implementations of freedesktop.org standards in python
 
 [[package]]
 name = "requests"
-version = "2.28.0"
+version = "2.28.1"
 requires_python = ">=3.7, <4"
 summary = "Python HTTP for Humans."
 dependencies = [
     "certifi>=2017.4.17",
-    "charset-normalizer~=2.0.0",
+    "charset-normalizer<3,>=2",
     "idna<4,>=2.5",
     "urllib3<1.27,>=1.21.1",
 ]
@@ -502,7 +502,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:09f8ecbce7faf3834439074a7187985d390bc02f27c9561648bec28caa4154e6"
+content_hash = "sha256:4016cab7fe1952b9e6a138e59cfc5160e11ca827c74f989dc9ce52ace5b349a4"
 
 [metadata.files]
 "appdirs 1.4.4" = [
@@ -542,9 +542,9 @@ content_hash = "sha256:09f8ecbce7faf3834439074a7187985d390bc02f27c9561648bec28ca
     {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
     {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
 ]
-"charset-normalizer 2.0.12" = [
-    {file = "charset_normalizer-2.0.12-py3-none-any.whl", hash = "sha256:6881edbebdb17b39b4eaaa821b438bf6eddffb4468cf344f09f89def34a8b1df"},
-    {file = "charset-normalizer-2.0.12.tar.gz", hash = "sha256:2857e29ff0d34db842cd7ca3230549d1a697f96ee6d3fb071cfa6c7393832597"},
+"charset-normalizer 2.1.0" = [
+    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
+    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
 ]
 "colorama 0.4.5" = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
@@ -850,9 +850,9 @@ content_hash = "sha256:09f8ecbce7faf3834439074a7187985d390bc02f27c9561648bec28ca
     {file = "pyxdg-0.28-py2.py3-none-any.whl", hash = "sha256:bdaf595999a0178ecea4052b7f4195569c1ff4d344567bccdc12dfdf02d545ab"},
     {file = "pyxdg-0.28.tar.gz", hash = "sha256:3267bb3074e934df202af2ee0868575484108581e6f3cb006af1da35395e88b4"},
 ]
-"requests 2.28.0" = [
-    {file = "requests-2.28.0-py3-none-any.whl", hash = "sha256:bc7861137fbce630f17b03d3ad02ad0bf978c844f3536d0edda6499dafce2b6f"},
-    {file = "requests-2.28.0.tar.gz", hash = "sha256:d568723a7ebd25875d8d1eaf5dfa068cd2fc8194b2e483d7b1f7c81918dbec6b"},
+"requests 2.28.1" = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
 ]
 "setuptools 62.6.0" = [
     {file = "setuptools-62.6.0-py3-none-any.whl", hash = "sha256:c1848f654aea2e3526d17fc3ce6aeaa5e7e24e66e645b5be2171f3f6b4e5a178"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "tox-pdm"
-version = "0.3.4"
+version = "0.5.0"
 requires_python = ">=3.7"
 summary = "A plugin for tox that utilizes PDM as the package manager and installer"
 dependencies = [
@@ -502,7 +502,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
-content_hash = "sha256:4016cab7fe1952b9e6a138e59cfc5160e11ca827c74f989dc9ce52ace5b349a4"
+content_hash = "sha256:4354609e32751b649996ce30626601b734f66158d7ee077ec6e01d28749bcacd"
 
 [metadata.files]
 "appdirs 1.4.4" = [
@@ -882,9 +882,9 @@ content_hash = "sha256:4016cab7fe1952b9e6a138e59cfc5160e11ca827c74f989dc9ce52ace
     {file = "tox_gh_actions-2.8.1-py2.py3-none-any.whl", hash = "sha256:9d22215a487f3c2f61ba0af5454010009b23fecf0a909b4a831a20d641a77369"},
     {file = "tox-gh-actions-2.8.1.tar.gz", hash = "sha256:43262d7ed1c126dacfd26b600641be4d51199622ce3b3e240e19b557fd4fa5a6"},
 ]
-"tox-pdm 0.3.4" = [
-    {file = "tox_pdm-0.3.4-py3-none-any.whl", hash = "sha256:0e019f6d41eed594fcf9a134b285d316c9d8ecf78343347a37d30c166b6390f0"},
-    {file = "tox-pdm-0.3.4.tar.gz", hash = "sha256:84db46a29b645221db97ac678267c66e7ad65ea3e0d70db39a755118a650022f"},
+"tox-pdm 0.5.0" = [
+    {file = "tox_pdm-0.5.0-py3-none-any.whl", hash = "sha256:0075ff9ed47ee13dc6e55122e6da121661a5553a633b8dd278013fbee81e4bb4"},
+    {file = "tox-pdm-0.5.0.tar.gz", hash = "sha256:45531c80c9670e7d9a0109ec5ab0d9add0492db4b41aa4ae0f20b295e4fd60e3"},
 ]
 "traitlets 5.3.0" = [
     {file = "traitlets-5.3.0-py3-none-any.whl", hash = "sha256:65fa18961659635933100db8ca120ef6220555286949774b9cfc106f941d1c7a"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -167,6 +167,7 @@ dependencies = [
 
 [[package]]
 <<<<<<< HEAD
+<<<<<<< HEAD
 ||||||| parent of 282c595 (Protocol type checking.)
 name = "importlib-resources"
 version = "5.6.0"
@@ -188,6 +189,18 @@ dependencies = [
 
 [[package]]
 >>>>>>> 282c595 (Protocol type checking.)
+||||||| parent of 6e0c75f (relock)
+name = "importlib-resources"
+version = "5.8.0"
+requires_python = ">=3.7"
+summary = "Read resources from Python packages"
+dependencies = [
+    "zipp>=3.1.0; python_version < \"3.10\"",
+]
+
+[[package]]
+=======
+>>>>>>> 6e0c75f (relock)
 name = "iniconfig"
 version = "1.1.1"
 summary = "iniconfig: brain-dead simple config-ini parsing"
@@ -479,6 +492,7 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
 name = "tox-gh-actions"
 version = "2.8.1"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
@@ -488,6 +502,19 @@ dependencies = [
 ]
 
 [[package]]
+||||||| parent of 6e0c75f (relock)
+name = "tox-gh-actions"
+version = "2.9.1"
+requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+summary = "Seamless integration of tox into GitHub Actions"
+dependencies = [
+    "importlib-resources",
+    "tox<4,>=3.12",
+]
+
+[[package]]
+=======
+>>>>>>> 6e0c75f (relock)
 name = "tox-pdm"
 <<<<<<< HEAD
 version = "0.3.4"
@@ -561,6 +588,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 lock_version = "3.1"
 <<<<<<< HEAD
 <<<<<<< HEAD
+<<<<<<< HEAD
 content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe632929d5a7e9"
 ||||||| parent of 282c595 (Protocol type checking.)
 content_hash = "sha256:2602c26d1397cce1eb7c1e675ba60538eb19f3d4f62ecdad24fa4ef4289e9b75"
@@ -572,6 +600,11 @@ content_hash = "sha256:b93a822ea67a73b40d5affd7e3b54c97094efb74be0cb732d6f01c06a
 =======
 content_hash = "sha256:fd8622f0ac629b3356824d58fc137f288987466c69370cc7009f82138b59995c"
 >>>>>>> 05d9ecd (relock)
+||||||| parent of 6e0c75f (relock)
+content_hash = "sha256:fd8622f0ac629b3356824d58fc137f288987466c69370cc7009f82138b59995c"
+=======
+content_hash = "sha256:dc8c977611e2bcb7106ebf5c4ae48485ea33fb6edf1e6f08c8fb9503b3ff4a71"
+>>>>>>> 6e0c75f (relock)
 
 [metadata.files]
 "appdirs 1.4.4" = [
@@ -775,11 +808,19 @@ content_hash = "sha256:fd8622f0ac629b3356824d58fc137f288987466c69370cc7009f82138
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
     {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
+<<<<<<< HEAD
 "importlib-resources 5.8.0" = [
     {file = "importlib_resources-5.8.0-py3-none-any.whl", hash = "sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223"},
     {file = "importlib_resources-5.8.0.tar.gz", hash = "sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751"},
 >>>>>>> 282c595 (Protocol type checking.)
 ]
+||||||| parent of 6e0c75f (relock)
+"importlib-resources 5.8.0" = [
+    {file = "importlib_resources-5.8.0-py3-none-any.whl", hash = "sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223"},
+    {file = "importlib_resources-5.8.0.tar.gz", hash = "sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751"},
+]
+=======
+>>>>>>> 6e0c75f (relock)
 "iniconfig 1.1.1" = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
@@ -1008,6 +1049,7 @@ content_hash = "sha256:fd8622f0ac629b3356824d58fc137f288987466c69370cc7009f82138
     {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
 <<<<<<< HEAD
+<<<<<<< HEAD
 "tox-gh-actions 2.8.1" = [
     {file = "tox_gh_actions-2.8.1-py2.py3-none-any.whl", hash = "sha256:9d22215a487f3c2f61ba0af5454010009b23fecf0a909b4a831a20d641a77369"},
     {file = "tox-gh-actions-2.8.1.tar.gz", hash = "sha256:43262d7ed1c126dacfd26b600641be4d51199622ce3b3e240e19b557fd4fa5a6"},
@@ -1096,6 +1138,13 @@ content_hash = "sha256:fd8622f0ac629b3356824d58fc137f288987466c69370cc7009f82138
     {file = "tox_gh_actions-2.9.1-py2.py3-none-any.whl", hash = "sha256:90306a6a04a203e47f861b35dca215fc1f6b7ae80de942a050ace61e2eb2b4ea"},
     {file = "tox-gh-actions-2.9.1.tar.gz", hash = "sha256:2bbb681eccd3fd3573231a05f7acf228caae1e3f12397b5517b404417ab90aba"},
 ]
+||||||| parent of 6e0c75f (relock)
+"tox-gh-actions 2.9.1" = [
+    {file = "tox_gh_actions-2.9.1-py2.py3-none-any.whl", hash = "sha256:90306a6a04a203e47f861b35dca215fc1f6b7ae80de942a050ace61e2eb2b4ea"},
+    {file = "tox-gh-actions-2.9.1.tar.gz", hash = "sha256:2bbb681eccd3fd3573231a05f7acf228caae1e3f12397b5517b404417ab90aba"},
+]
+=======
+>>>>>>> 6e0c75f (relock)
 "tox-pdm 0.5.0" = [
     {file = "tox_pdm-0.5.0-py3-none-any.whl", hash = "sha256:0075ff9ed47ee13dc6e55122e6da121661a5553a633b8dd278013fbee81e4bb4"},
     {file = "tox-pdm-0.5.0.tar.gz", hash = "sha256:45531c80c9670e7d9a0109ec5ab0d9add0492db4b41aa4ae0f20b295e4fd60e3"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -560,12 +560,18 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 [metadata]
 lock_version = "3.1"
 <<<<<<< HEAD
+<<<<<<< HEAD
 content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe632929d5a7e9"
 ||||||| parent of 282c595 (Protocol type checking.)
 content_hash = "sha256:2602c26d1397cce1eb7c1e675ba60538eb19f3d4f62ecdad24fa4ef4289e9b75"
 =======
 content_hash = "sha256:b93a822ea67a73b40d5affd7e3b54c97094efb74be0cb732d6f01c06ada1040d"
 >>>>>>> 282c595 (Protocol type checking.)
+||||||| parent of 05d9ecd (relock)
+content_hash = "sha256:b93a822ea67a73b40d5affd7e3b54c97094efb74be0cb732d6f01c06ada1040d"
+=======
+content_hash = "sha256:fd8622f0ac629b3356824d58fc137f288987466c69370cc7009f82138b59995c"
+>>>>>>> 05d9ecd (relock)
 
 [metadata.files]
 "appdirs 1.4.4" = [

--- a/pdm.lock
+++ b/pdm.lock
@@ -222,16 +222,13 @@ dependencies = [
 
 [[package]]
 name = "pandas"
-version = "1.3.5"
-requires_python = ">=3.7.1"
+version = "1.1.5"
+requires_python = ">=3.6.1"
 summary = "Powerful data structures for data analysis, time series, and statistics"
 dependencies = [
-    "numpy>=1.17.3; platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\"",
-    "numpy>=1.19.2; platform_machine == \"aarch64\" and python_version < \"3.10\"",
-    "numpy>=1.20.0; platform_machine == \"arm64\" and python_version < \"3.10\"",
-    "numpy>=1.21.0; python_version >= \"3.10\"",
+    "numpy>=1.15.4",
     "python-dateutil>=2.7.3",
-    "pytz>=2017.3",
+    "pytz>=2017.2",
 ]
 
 [[package]]
@@ -418,7 +415,7 @@ summary = "A lil' TOML parser"
 
 [[package]]
 name = "tox"
-version = "3.24.5"
+version = "3.25.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "tox is a generic virtualenv management and test command line tool"
 dependencies = [
@@ -874,9 +871,9 @@ content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe63292
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-"tox 3.24.5" = [
-    {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
-    {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
+"tox 3.25.0" = [
+    {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
+    {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
 "tox-gh-actions 2.8.1" = [
     {file = "tox_gh_actions-2.8.1-py2.py3-none-any.whl", hash = "sha256:9d22215a487f3c2f61ba0af5454010009b23fecf0a909b4a831a20d641a77369"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -101,6 +101,12 @@ version = "0.3.4"
 summary = "Distribution utilities"
 
 [[package]]
+name = "exceptiongroup"
+version = "1.0.0rc8"
+requires_python = ">=3.7"
+summary = "Backport of PEP 654 (exception groups)"
+
+[[package]]
 name = "filelock"
 version = "3.7.1"
 requires_python = ">=3.7"
@@ -126,11 +132,20 @@ summary = "Lightweight in-process concurrent programming"
 
 [[package]]
 name = "hypothesis"
+<<<<<<< HEAD
 version = "6.21.6"
 requires_python = ">=3.6"
+||||||| parent of 282c595 (Protocol type checking.)
+version = "6.39.6"
+requires_python = ">=3.7"
+=======
+version = "6.48.1"
+requires_python = ">=3.7"
+>>>>>>> 282c595 (Protocol type checking.)
 summary = "A library for property-based testing"
 dependencies = [
     "attrs>=19.2.0",
+    "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
     "sortedcontainers<3.0.0,>=2.1.0",
 ]
 
@@ -151,14 +166,44 @@ dependencies = [
 ]
 
 [[package]]
+<<<<<<< HEAD
+||||||| parent of 282c595 (Protocol type checking.)
+name = "importlib-resources"
+version = "5.6.0"
+requires_python = ">=3.7"
+summary = "Read resources from Python packages"
+dependencies = [
+    "zipp>=3.1.0; python_version < \"3.10\"",
+]
+
+[[package]]
+=======
+name = "importlib-resources"
+version = "5.8.0"
+requires_python = ">=3.7"
+summary = "Read resources from Python packages"
+dependencies = [
+    "zipp>=3.1.0; python_version < \"3.10\"",
+]
+
+[[package]]
+>>>>>>> 282c595 (Protocol type checking.)
 name = "iniconfig"
 version = "1.1.1"
 summary = "iniconfig: brain-dead simple config-ini parsing"
 
 [[package]]
 name = "ipython"
+<<<<<<< HEAD
 version = "7.16.3"
 requires_python = ">=3.6"
+||||||| parent of 282c595 (Protocol type checking.)
+version = "7.32.0"
+requires_python = ">=3.7"
+=======
+version = "7.34.0"
+requires_python = ">=3.7"
+>>>>>>> 282c595 (Protocol type checking.)
 summary = "IPython: Productive Interactive Computing"
 dependencies = [
     "appnope; sys_platform == \"darwin\"",
@@ -418,7 +463,7 @@ summary = "A lil' TOML parser"
 
 [[package]]
 name = "tox"
-version = "3.24.5"
+version = "3.25.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "tox is a generic virtualenv management and test command line tool"
 dependencies = [
@@ -444,7 +489,13 @@ dependencies = [
 
 [[package]]
 name = "tox-pdm"
+<<<<<<< HEAD
 version = "0.3.4"
+||||||| parent of 282c595 (Protocol type checking.)
+version = "0.3.3"
+=======
+version = "0.5.0"
+>>>>>>> 282c595 (Protocol type checking.)
 requires_python = ">=3.7"
 summary = "A plugin for tox that utilizes PDM as the package manager and installer"
 dependencies = [
@@ -478,7 +529,13 @@ summary = "HTTP library with thread-safe connection pooling, file post, and more
 
 [[package]]
 name = "virtualenv"
+<<<<<<< HEAD
 version = "20.15.1"
+||||||| parent of 282c595 (Protocol type checking.)
+version = "20.14.0"
+=======
+version = "20.15.0"
+>>>>>>> 282c595 (Protocol type checking.)
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "Virtual Python Environment builder"
 dependencies = [
@@ -502,7 +559,13 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
+<<<<<<< HEAD
 content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe632929d5a7e9"
+||||||| parent of 282c595 (Protocol type checking.)
+content_hash = "sha256:2602c26d1397cce1eb7c1e675ba60538eb19f3d4f62ecdad24fa4ef4289e9b75"
+=======
+content_hash = "sha256:b93a822ea67a73b40d5affd7e3b54c97094efb74be0cb732d6f01c06ada1040d"
+>>>>>>> 282c595 (Protocol type checking.)
 
 [metadata.files]
 "appdirs 1.4.4" = [
@@ -592,9 +655,23 @@ content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe63292
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
+<<<<<<< HEAD
 "filelock 3.7.1" = [
     {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
     {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
+||||||| parent of 282c595 (Protocol type checking.)
+"filelock 3.6.0" = [
+    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
+    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
+=======
+"exceptiongroup 1.0.0rc8" = [
+    {file = "exceptiongroup-1.0.0rc8-py3-none-any.whl", hash = "sha256:ab0a968e1ef769e55d9a596f4a89f7be9ffedbc9fdefdb77cc68cf5c33ce1035"},
+    {file = "exceptiongroup-1.0.0rc8.tar.gz", hash = "sha256:6990c24f06b8d33c8065cfe43e5e8a4bfa384e0358be036af9cc60b6321bd11a"},
+]
+"filelock 3.7.1" = [
+    {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
+    {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
+>>>>>>> 282c595 (Protocol type checking.)
 ]
 "flake8 3.9.2" = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -657,25 +734,71 @@ content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe63292
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
 ]
+<<<<<<< HEAD
 "hypothesis 6.21.6" = [
     {file = "hypothesis-6.21.6-py3-none-any.whl", hash = "sha256:1a96c67658f0fca00476380c2c7323066e2fb1d45a2b0874dd07fd0643b49b46"},
     {file = "hypothesis-6.21.6.tar.gz", hash = "sha256:29b72005910f2a548d727e5d5accf862a6ae84e49176d748fb6ca040ef657592"},
+||||||| parent of 282c595 (Protocol type checking.)
+"hypothesis 6.39.6" = [
+    {file = "hypothesis-6.39.6-py3-none-any.whl", hash = "sha256:1577ac8baa9c77ee3c946124c7b69551e127c4440f9e56fa6ed49bc73dabbf49"},
+    {file = "hypothesis-6.39.6.tar.gz", hash = "sha256:7cc9056edeab51ce195b3b6994f2446f0aac405d191cab7e2de5e159cb4c2bc2"},
+=======
+"hypothesis 6.48.1" = [
+    {file = "hypothesis-6.48.1-py3-none-any.whl", hash = "sha256:1f605e8e50d3e29d14ac8c0bf1c53ac66f3515f3a0e09abb07bdd7a9dc4dcaaf"},
+    {file = "hypothesis-6.48.1.tar.gz", hash = "sha256:5b296c32a57e50555841dd742f2cd96c0b7ba1687730b0ef34b506d0f76b4a68"},
+>>>>>>> 282c595 (Protocol type checking.)
 ]
 "idna 3.3" = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
+<<<<<<< HEAD
 "importlib-metadata 4.12.0" = [
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
     {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
+||||||| parent of 282c595 (Protocol type checking.)
+"importlib-metadata 4.11.3" = [
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
+]
+"importlib-resources 5.6.0" = [
+    {file = "importlib_resources-5.6.0-py3-none-any.whl", hash = "sha256:a9dd72f6cc106aeb50f6e66b86b69b454766dd6e39b69ac68450253058706bcc"},
+    {file = "importlib_resources-5.6.0.tar.gz", hash = "sha256:1b93238cbf23b4cde34240dd8321d99e9bf2eb4bc91c0c99b2886283e7baad85"},
+=======
+"importlib-metadata 4.12.0" = [
+    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
+    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
+]
+"importlib-resources 5.8.0" = [
+    {file = "importlib_resources-5.8.0-py3-none-any.whl", hash = "sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223"},
+    {file = "importlib_resources-5.8.0.tar.gz", hash = "sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751"},
+>>>>>>> 282c595 (Protocol type checking.)
 ]
 "iniconfig 1.1.1" = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
+<<<<<<< HEAD
 "ipython 7.16.3" = [
     {file = "ipython-7.16.3-py3-none-any.whl", hash = "sha256:c0427ed8bc33ac481faf9d3acf7e84e0010cdaada945e0badd1e2e74cc075833"},
     {file = "ipython-7.16.3.tar.gz", hash = "sha256:5ac47dc9af66fc2f5530c12069390877ae372ac905edca75a92a6e363b5d7caa"},
+||||||| parent of 282c595 (Protocol type checking.)
+"ipython 7.32.0" = [
+    {file = "ipython-7.32.0-py3-none-any.whl", hash = "sha256:86df2cf291c6c70b5be6a7b608650420e89180c8ec74f376a34e2dc15c3400e7"},
+    {file = "ipython-7.32.0.tar.gz", hash = "sha256:468abefc45c15419e3c8e8c0a6a5c115b2127bafa34d7c641b1d443658793909"},
+]
+"jedi 0.18.1" = [
+    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
+    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
+=======
+"ipython 7.34.0" = [
+    {file = "ipython-7.34.0-py3-none-any.whl", hash = "sha256:c175d2440a1caff76116eb719d40538fbb316e214eda85c5515c303aacbfb23e"},
+    {file = "ipython-7.34.0.tar.gz", hash = "sha256:af3bdb46aa292bce5615b1b2ebc76c2080c5f77f54bda2ec72461317273e7cd6"},
+]
+"jedi 0.18.1" = [
+    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
+    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
+>>>>>>> 282c595 (Protocol type checking.)
 ]
 "jedi 0.17.2" = [
     {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
@@ -874,10 +997,11 @@ content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe63292
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-"tox 3.24.5" = [
-    {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
-    {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
+"tox 3.25.0" = [
+    {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
+    {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
+<<<<<<< HEAD
 "tox-gh-actions 2.8.1" = [
     {file = "tox_gh_actions-2.8.1-py2.py3-none-any.whl", hash = "sha256:9d22215a487f3c2f61ba0af5454010009b23fecf0a909b4a831a20d641a77369"},
     {file = "tox-gh-actions-2.8.1.tar.gz", hash = "sha256:43262d7ed1c126dacfd26b600641be4d51199622ce3b3e240e19b557fd4fa5a6"},
@@ -919,14 +1043,109 @@ content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe63292
 "typing-extensions 4.2.0" = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
     {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
+||||||| parent of 282c595 (Protocol type checking.)
+"tox-gh-actions 2.9.1" = [
+    {file = "tox_gh_actions-2.9.1-py2.py3-none-any.whl", hash = "sha256:90306a6a04a203e47f861b35dca215fc1f6b7ae80de942a050ace61e2eb2b4ea"},
+    {file = "tox-gh-actions-2.9.1.tar.gz", hash = "sha256:2bbb681eccd3fd3573231a05f7acf228caae1e3f12397b5517b404417ab90aba"},
+]
+"tox-pdm 0.3.3" = [
+    {file = "tox_pdm-0.3.3-py3-none-any.whl", hash = "sha256:3675cc2ae1d1030be20a954c997f435b8224bb4491f7268c2424b012f9334a50"},
+    {file = "tox-pdm-0.3.3.tar.gz", hash = "sha256:c4d35a4ab95f248d8c9ad730fd78e018eb31b7642ee7dbde2dd0ace6ddb692b0"},
+]
+"traitlets 5.1.1" = [
+    {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},
+    {file = "traitlets-5.1.1.tar.gz", hash = "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7"},
+]
+"typed-ast 1.5.2" = [
+    {file = "typed_ast-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266"},
+    {file = "typed_ast-1.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596"},
+    {file = "typed_ast-1.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc2542e83ac8399752bc16e0b35e038bdb659ba237f4222616b4e83fb9654985"},
+    {file = "typed_ast-1.5.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74cac86cc586db8dfda0ce65d8bcd2bf17b58668dfcc3652762f3ef0e6677e76"},
+    {file = "typed_ast-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:18fe320f354d6f9ad3147859b6e16649a0781425268c4dde596093177660e71a"},
+    {file = "typed_ast-1.5.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:31d8c6b2df19a777bc8826770b872a45a1f30cfefcfd729491baa5237faae837"},
+    {file = "typed_ast-1.5.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:963a0ccc9a4188524e6e6d39b12c9ca24cc2d45a71cfdd04a26d883c922b4b78"},
+    {file = "typed_ast-1.5.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0eb77764ea470f14fcbb89d51bc6bbf5e7623446ac4ed06cbd9ca9495b62e36e"},
+    {file = "typed_ast-1.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:294a6903a4d087db805a7656989f613371915fc45c8cc0ddc5c5a0a8ad9bea4d"},
+    {file = "typed_ast-1.5.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26a432dc219c6b6f38be20a958cbe1abffcc5492821d7e27f08606ef99e0dffd"},
+    {file = "typed_ast-1.5.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7407cfcad702f0b6c0e0f3e7ab876cd1d2c13b14ce770e412c0c4b9728a0f88"},
+    {file = "typed_ast-1.5.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f30ddd110634c2d7534b2d4e0e22967e88366b0d356b24de87419cc4410c41b7"},
+    {file = "typed_ast-1.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8c08d6625bb258179b6e512f55ad20f9dfef019bbfbe3095247401e053a3ea30"},
+    {file = "typed_ast-1.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:90904d889ab8e81a956f2c0935a523cc4e077c7847a836abee832f868d5c26a4"},
+    {file = "typed_ast-1.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:bbebc31bf11762b63bf61aaae232becb41c5bf6b3461b80a4df7e791fabb3aca"},
+    {file = "typed_ast-1.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c29dd9a3a9d259c9fa19d19738d021632d673f6ed9b35a739f48e5f807f264fb"},
+    {file = "typed_ast-1.5.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:58ae097a325e9bb7a684572d20eb3e1809802c5c9ec7108e85da1eb6c1a3331b"},
+    {file = "typed_ast-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:da0a98d458010bf4fe535f2d1e367a2e2060e105978873c04c04212fb20543f7"},
+    {file = "typed_ast-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:33b4a19ddc9fc551ebabca9765d54d04600c4a50eda13893dadf67ed81d9a098"},
+    {file = "typed_ast-1.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1098df9a0592dd4c8c0ccfc2e98931278a6c6c53cb3a3e2cf7e9ee3b06153344"},
+    {file = "typed_ast-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c47c3b43fe3a39ddf8de1d40dbbfca60ac8530a36c9b198ea5b9efac75c09e"},
+    {file = "typed_ast-1.5.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f290617f74a610849bd8f5514e34ae3d09eafd521dceaa6cf68b3f4414266d4e"},
+    {file = "typed_ast-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:df05aa5b241e2e8045f5f4367a9f6187b09c4cdf8578bb219861c4e27c443db5"},
+    {file = "typed_ast-1.5.2.tar.gz", hash = "sha256:525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27"},
+]
+"typing-extensions 4.1.1" = [
+    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
+    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
+=======
+"tox-gh-actions 2.9.1" = [
+    {file = "tox_gh_actions-2.9.1-py2.py3-none-any.whl", hash = "sha256:90306a6a04a203e47f861b35dca215fc1f6b7ae80de942a050ace61e2eb2b4ea"},
+    {file = "tox-gh-actions-2.9.1.tar.gz", hash = "sha256:2bbb681eccd3fd3573231a05f7acf228caae1e3f12397b5517b404417ab90aba"},
+]
+"tox-pdm 0.5.0" = [
+    {file = "tox_pdm-0.5.0-py3-none-any.whl", hash = "sha256:0075ff9ed47ee13dc6e55122e6da121661a5553a633b8dd278013fbee81e4bb4"},
+    {file = "tox-pdm-0.5.0.tar.gz", hash = "sha256:45531c80c9670e7d9a0109ec5ab0d9add0492db4b41aa4ae0f20b295e4fd60e3"},
+]
+"traitlets 5.3.0" = [
+    {file = "traitlets-5.3.0-py3-none-any.whl", hash = "sha256:65fa18961659635933100db8ca120ef6220555286949774b9cfc106f941d1c7a"},
+    {file = "traitlets-5.3.0.tar.gz", hash = "sha256:0bb9f1f9f017aa8ec187d8b1b2a7a6626a2a1d877116baba52a129bfa124f8e2"},
+]
+"typed-ast 1.5.4" = [
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
+    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
+    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
+    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
+    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+"typing-extensions 4.2.0" = [
+    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
+    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
+>>>>>>> 282c595 (Protocol type checking.)
 ]
 "urllib3 1.26.9" = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
     {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]
+<<<<<<< HEAD
 "virtualenv 20.15.1" = [
     {file = "virtualenv-20.15.1-py2.py3-none-any.whl", hash = "sha256:b30aefac647e86af6d82bfc944c556f8f1a9c90427b2fb4e3bfbf338cb82becf"},
     {file = "virtualenv-20.15.1.tar.gz", hash = "sha256:288171134a2ff3bfb1a2f54f119e77cd1b81c29fc1265a2356f3e8d14c7d58c4"},
+||||||| parent of 282c595 (Protocol type checking.)
+"virtualenv 20.14.0" = [
+    {file = "virtualenv-20.14.0-py2.py3-none-any.whl", hash = "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66"},
+    {file = "virtualenv-20.14.0.tar.gz", hash = "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"},
+=======
+"virtualenv 20.15.0" = [
+    {file = "virtualenv-20.15.0-py2.py3-none-any.whl", hash = "sha256:804cce4de5b8a322f099897e308eecc8f6e2951f1a8e7e2b3598dff865f01336"},
+    {file = "virtualenv-20.15.0.tar.gz", hash = "sha256:4c44b1d77ca81f8368e2d7414f9b20c428ad16b343ac6d226206c5b84e2b4fcc"},
+>>>>>>> 282c595 (Protocol type checking.)
 ]
 "wcwidth 0.2.5" = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -415,7 +415,7 @@ summary = "A lil' TOML parser"
 
 [[package]]
 name = "tox"
-version = "3.25.0"
+version = "3.24.5"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "tox is a generic virtualenv management and test command line tool"
 dependencies = [
@@ -871,9 +871,9 @@ content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe63292
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-"tox 3.25.0" = [
-    {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
-    {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
+"tox 3.24.5" = [
+    {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
+    {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
 ]
 "tox-gh-actions 2.8.1" = [
     {file = "tox_gh_actions-2.8.1-py2.py3-none-any.whl", hash = "sha256:9d22215a487f3c2f61ba0af5454010009b23fecf0a909b4a831a20d641a77369"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -101,12 +101,6 @@ version = "0.3.4"
 summary = "Distribution utilities"
 
 [[package]]
-name = "exceptiongroup"
-version = "1.0.0rc8"
-requires_python = ">=3.7"
-summary = "Backport of PEP 654 (exception groups)"
-
-[[package]]
 name = "filelock"
 version = "3.7.1"
 requires_python = ">=3.7"
@@ -132,20 +126,11 @@ summary = "Lightweight in-process concurrent programming"
 
 [[package]]
 name = "hypothesis"
-<<<<<<< HEAD
 version = "6.21.6"
 requires_python = ">=3.6"
-||||||| parent of 282c595 (Protocol type checking.)
-version = "6.39.6"
-requires_python = ">=3.7"
-=======
-version = "6.48.1"
-requires_python = ">=3.7"
->>>>>>> 282c595 (Protocol type checking.)
 summary = "A library for property-based testing"
 dependencies = [
     "attrs>=19.2.0",
-    "exceptiongroup>=1.0.0rc8; python_version < \"3.11\"",
     "sortedcontainers<3.0.0,>=2.1.0",
 ]
 
@@ -166,57 +151,14 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
-<<<<<<< HEAD
-||||||| parent of 282c595 (Protocol type checking.)
-name = "importlib-resources"
-version = "5.6.0"
-requires_python = ">=3.7"
-summary = "Read resources from Python packages"
-dependencies = [
-    "zipp>=3.1.0; python_version < \"3.10\"",
-]
-
-[[package]]
-=======
-name = "importlib-resources"
-version = "5.8.0"
-requires_python = ">=3.7"
-summary = "Read resources from Python packages"
-dependencies = [
-    "zipp>=3.1.0; python_version < \"3.10\"",
-]
-
-[[package]]
->>>>>>> 282c595 (Protocol type checking.)
-||||||| parent of 6e0c75f (relock)
-name = "importlib-resources"
-version = "5.8.0"
-requires_python = ">=3.7"
-summary = "Read resources from Python packages"
-dependencies = [
-    "zipp>=3.1.0; python_version < \"3.10\"",
-]
-
-[[package]]
-=======
->>>>>>> 6e0c75f (relock)
 name = "iniconfig"
 version = "1.1.1"
 summary = "iniconfig: brain-dead simple config-ini parsing"
 
 [[package]]
 name = "ipython"
-<<<<<<< HEAD
 version = "7.16.3"
 requires_python = ">=3.6"
-||||||| parent of 282c595 (Protocol type checking.)
-version = "7.32.0"
-requires_python = ">=3.7"
-=======
-version = "7.34.0"
-requires_python = ">=3.7"
->>>>>>> 282c595 (Protocol type checking.)
 summary = "IPython: Productive Interactive Computing"
 dependencies = [
     "appnope; sys_platform == \"darwin\"",
@@ -476,7 +418,7 @@ summary = "A lil' TOML parser"
 
 [[package]]
 name = "tox"
-version = "3.25.0"
+version = "3.24.5"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "tox is a generic virtualenv management and test command line tool"
 dependencies = [
@@ -492,7 +434,6 @@ dependencies = [
 ]
 
 [[package]]
-<<<<<<< HEAD
 name = "tox-gh-actions"
 version = "2.8.1"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
@@ -502,27 +443,8 @@ dependencies = [
 ]
 
 [[package]]
-||||||| parent of 6e0c75f (relock)
-name = "tox-gh-actions"
-version = "2.9.1"
-requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
-summary = "Seamless integration of tox into GitHub Actions"
-dependencies = [
-    "importlib-resources",
-    "tox<4,>=3.12",
-]
-
-[[package]]
-=======
->>>>>>> 6e0c75f (relock)
 name = "tox-pdm"
-<<<<<<< HEAD
 version = "0.3.4"
-||||||| parent of 282c595 (Protocol type checking.)
-version = "0.3.3"
-=======
-version = "0.5.0"
->>>>>>> 282c595 (Protocol type checking.)
 requires_python = ">=3.7"
 summary = "A plugin for tox that utilizes PDM as the package manager and installer"
 dependencies = [
@@ -556,13 +478,7 @@ summary = "HTTP library with thread-safe connection pooling, file post, and more
 
 [[package]]
 name = "virtualenv"
-<<<<<<< HEAD
 version = "20.15.1"
-||||||| parent of 282c595 (Protocol type checking.)
-version = "20.14.0"
-=======
-version = "20.15.0"
->>>>>>> 282c595 (Protocol type checking.)
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "Virtual Python Environment builder"
 dependencies = [
@@ -586,25 +502,7 @@ summary = "Backport of pathlib-compatible object wrapper for zip files"
 
 [metadata]
 lock_version = "3.1"
-<<<<<<< HEAD
-<<<<<<< HEAD
-<<<<<<< HEAD
-content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe632929d5a7e9"
-||||||| parent of 282c595 (Protocol type checking.)
-content_hash = "sha256:2602c26d1397cce1eb7c1e675ba60538eb19f3d4f62ecdad24fa4ef4289e9b75"
-=======
-content_hash = "sha256:b93a822ea67a73b40d5affd7e3b54c97094efb74be0cb732d6f01c06ada1040d"
->>>>>>> 282c595 (Protocol type checking.)
-||||||| parent of 05d9ecd (relock)
-content_hash = "sha256:b93a822ea67a73b40d5affd7e3b54c97094efb74be0cb732d6f01c06ada1040d"
-=======
-content_hash = "sha256:fd8622f0ac629b3356824d58fc137f288987466c69370cc7009f82138b59995c"
->>>>>>> 05d9ecd (relock)
-||||||| parent of 6e0c75f (relock)
-content_hash = "sha256:fd8622f0ac629b3356824d58fc137f288987466c69370cc7009f82138b59995c"
-=======
-content_hash = "sha256:dc8c977611e2bcb7106ebf5c4ae48485ea33fb6edf1e6f08c8fb9503b3ff4a71"
->>>>>>> 6e0c75f (relock)
+content_hash = "sha256:09f8ecbce7faf3834439074a7187985d390bc02f27c9561648bec28caa4154e6"
 
 [metadata.files]
 "appdirs 1.4.4" = [
@@ -694,23 +592,9 @@ content_hash = "sha256:dc8c977611e2bcb7106ebf5c4ae48485ea33fb6edf1e6f08c8fb9503b
     {file = "distlib-0.3.4-py2.py3-none-any.whl", hash = "sha256:6564fe0a8f51e734df6333d08b8b94d4ea8ee6b99b5ed50613f731fd4089f34b"},
     {file = "distlib-0.3.4.zip", hash = "sha256:e4b58818180336dc9c529bfb9a0b58728ffc09ad92027a3f30b7cd91e3458579"},
 ]
-<<<<<<< HEAD
 "filelock 3.7.1" = [
     {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
     {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
-||||||| parent of 282c595 (Protocol type checking.)
-"filelock 3.6.0" = [
-    {file = "filelock-3.6.0-py3-none-any.whl", hash = "sha256:f8314284bfffbdcfa0ff3d7992b023d4c628ced6feb957351d4c48d059f56bc0"},
-    {file = "filelock-3.6.0.tar.gz", hash = "sha256:9cd540a9352e432c7246a48fe4e8712b10acb1df2ad1f30e8c070b82ae1fed85"},
-=======
-"exceptiongroup 1.0.0rc8" = [
-    {file = "exceptiongroup-1.0.0rc8-py3-none-any.whl", hash = "sha256:ab0a968e1ef769e55d9a596f4a89f7be9ffedbc9fdefdb77cc68cf5c33ce1035"},
-    {file = "exceptiongroup-1.0.0rc8.tar.gz", hash = "sha256:6990c24f06b8d33c8065cfe43e5e8a4bfa384e0358be036af9cc60b6321bd11a"},
-]
-"filelock 3.7.1" = [
-    {file = "filelock-3.7.1-py3-none-any.whl", hash = "sha256:37def7b658813cda163b56fc564cdc75e86d338246458c4c28ae84cabefa2404"},
-    {file = "filelock-3.7.1.tar.gz", hash = "sha256:3a0fd85166ad9dbab54c9aec96737b744106dc5f15c0b09a6744a445299fcf04"},
->>>>>>> 282c595 (Protocol type checking.)
 ]
 "flake8 3.9.2" = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
@@ -773,79 +657,25 @@ content_hash = "sha256:dc8c977611e2bcb7106ebf5c4ae48485ea33fb6edf1e6f08c8fb9503b
     {file = "greenlet-1.1.2-cp39-cp39-win_amd64.whl", hash = "sha256:013d61294b6cd8fe3242932c1c5e36e5d1db2c8afb58606c5a67efce62c1f5fd"},
     {file = "greenlet-1.1.2.tar.gz", hash = "sha256:e30f5ea4ae2346e62cedde8794a56858a67b878dd79f7df76a0767e356b1744a"},
 ]
-<<<<<<< HEAD
 "hypothesis 6.21.6" = [
     {file = "hypothesis-6.21.6-py3-none-any.whl", hash = "sha256:1a96c67658f0fca00476380c2c7323066e2fb1d45a2b0874dd07fd0643b49b46"},
     {file = "hypothesis-6.21.6.tar.gz", hash = "sha256:29b72005910f2a548d727e5d5accf862a6ae84e49176d748fb6ca040ef657592"},
-||||||| parent of 282c595 (Protocol type checking.)
-"hypothesis 6.39.6" = [
-    {file = "hypothesis-6.39.6-py3-none-any.whl", hash = "sha256:1577ac8baa9c77ee3c946124c7b69551e127c4440f9e56fa6ed49bc73dabbf49"},
-    {file = "hypothesis-6.39.6.tar.gz", hash = "sha256:7cc9056edeab51ce195b3b6994f2446f0aac405d191cab7e2de5e159cb4c2bc2"},
-=======
-"hypothesis 6.48.1" = [
-    {file = "hypothesis-6.48.1-py3-none-any.whl", hash = "sha256:1f605e8e50d3e29d14ac8c0bf1c53ac66f3515f3a0e09abb07bdd7a9dc4dcaaf"},
-    {file = "hypothesis-6.48.1.tar.gz", hash = "sha256:5b296c32a57e50555841dd742f2cd96c0b7ba1687730b0ef34b506d0f76b4a68"},
->>>>>>> 282c595 (Protocol type checking.)
 ]
 "idna 3.3" = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-<<<<<<< HEAD
-"importlib-metadata 4.12.0" = [
-    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
-    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
-||||||| parent of 282c595 (Protocol type checking.)
-"importlib-metadata 4.11.3" = [
-    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
-    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
-]
-"importlib-resources 5.6.0" = [
-    {file = "importlib_resources-5.6.0-py3-none-any.whl", hash = "sha256:a9dd72f6cc106aeb50f6e66b86b69b454766dd6e39b69ac68450253058706bcc"},
-    {file = "importlib_resources-5.6.0.tar.gz", hash = "sha256:1b93238cbf23b4cde34240dd8321d99e9bf2eb4bc91c0c99b2886283e7baad85"},
-=======
 "importlib-metadata 4.12.0" = [
     {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
     {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
 ]
-<<<<<<< HEAD
-"importlib-resources 5.8.0" = [
-    {file = "importlib_resources-5.8.0-py3-none-any.whl", hash = "sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223"},
-    {file = "importlib_resources-5.8.0.tar.gz", hash = "sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751"},
->>>>>>> 282c595 (Protocol type checking.)
-]
-||||||| parent of 6e0c75f (relock)
-"importlib-resources 5.8.0" = [
-    {file = "importlib_resources-5.8.0-py3-none-any.whl", hash = "sha256:7952325ffd516c05a8ad0858c74dff2c3343f136fe66a6002b2623dd1d43f223"},
-    {file = "importlib_resources-5.8.0.tar.gz", hash = "sha256:568c9f16cb204f9decc8d6d24a572eeea27dacbb4cee9e6b03a8025736769751"},
-]
-=======
->>>>>>> 6e0c75f (relock)
 "iniconfig 1.1.1" = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
-<<<<<<< HEAD
 "ipython 7.16.3" = [
     {file = "ipython-7.16.3-py3-none-any.whl", hash = "sha256:c0427ed8bc33ac481faf9d3acf7e84e0010cdaada945e0badd1e2e74cc075833"},
     {file = "ipython-7.16.3.tar.gz", hash = "sha256:5ac47dc9af66fc2f5530c12069390877ae372ac905edca75a92a6e363b5d7caa"},
-||||||| parent of 282c595 (Protocol type checking.)
-"ipython 7.32.0" = [
-    {file = "ipython-7.32.0-py3-none-any.whl", hash = "sha256:86df2cf291c6c70b5be6a7b608650420e89180c8ec74f376a34e2dc15c3400e7"},
-    {file = "ipython-7.32.0.tar.gz", hash = "sha256:468abefc45c15419e3c8e8c0a6a5c115b2127bafa34d7c641b1d443658793909"},
-]
-"jedi 0.18.1" = [
-    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
-    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
-=======
-"ipython 7.34.0" = [
-    {file = "ipython-7.34.0-py3-none-any.whl", hash = "sha256:c175d2440a1caff76116eb719d40538fbb316e214eda85c5515c303aacbfb23e"},
-    {file = "ipython-7.34.0.tar.gz", hash = "sha256:af3bdb46aa292bce5615b1b2ebc76c2080c5f77f54bda2ec72461317273e7cd6"},
-]
-"jedi 0.18.1" = [
-    {file = "jedi-0.18.1-py2.py3-none-any.whl", hash = "sha256:637c9635fcf47945ceb91cd7f320234a7be540ded6f3e99a50cb6febdfd1ba8d"},
-    {file = "jedi-0.18.1.tar.gz", hash = "sha256:74137626a64a99c8eb6ae5832d99b3bdd7d29a3850fe2aa80a4126b2a7d949ab"},
->>>>>>> 282c595 (Protocol type checking.)
 ]
 "jedi 0.17.2" = [
     {file = "jedi-0.17.2-py2.py3-none-any.whl", hash = "sha256:98cc583fa0f2f8304968199b01b6b4b94f469a1f4a74c1560506ca2a211378b5"},
@@ -1044,12 +874,10 @@ content_hash = "sha256:dc8c977611e2bcb7106ebf5c4ae48485ea33fb6edf1e6f08c8fb9503b
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-"tox 3.25.0" = [
-    {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
-    {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
+"tox 3.24.5" = [
+    {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
+    {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
 ]
-<<<<<<< HEAD
-<<<<<<< HEAD
 "tox-gh-actions 2.8.1" = [
     {file = "tox_gh_actions-2.8.1-py2.py3-none-any.whl", hash = "sha256:9d22215a487f3c2f61ba0af5454010009b23fecf0a909b4a831a20d641a77369"},
     {file = "tox-gh-actions-2.8.1.tar.gz", hash = "sha256:43262d7ed1c126dacfd26b600641be4d51199622ce3b3e240e19b557fd4fa5a6"},
@@ -1091,116 +919,14 @@ content_hash = "sha256:dc8c977611e2bcb7106ebf5c4ae48485ea33fb6edf1e6f08c8fb9503b
 "typing-extensions 4.2.0" = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
     {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
-||||||| parent of 282c595 (Protocol type checking.)
-"tox-gh-actions 2.9.1" = [
-    {file = "tox_gh_actions-2.9.1-py2.py3-none-any.whl", hash = "sha256:90306a6a04a203e47f861b35dca215fc1f6b7ae80de942a050ace61e2eb2b4ea"},
-    {file = "tox-gh-actions-2.9.1.tar.gz", hash = "sha256:2bbb681eccd3fd3573231a05f7acf228caae1e3f12397b5517b404417ab90aba"},
-]
-"tox-pdm 0.3.3" = [
-    {file = "tox_pdm-0.3.3-py3-none-any.whl", hash = "sha256:3675cc2ae1d1030be20a954c997f435b8224bb4491f7268c2424b012f9334a50"},
-    {file = "tox-pdm-0.3.3.tar.gz", hash = "sha256:c4d35a4ab95f248d8c9ad730fd78e018eb31b7642ee7dbde2dd0ace6ddb692b0"},
-]
-"traitlets 5.1.1" = [
-    {file = "traitlets-5.1.1-py3-none-any.whl", hash = "sha256:2d313cc50a42cd6c277e7d7dc8d4d7fedd06a2c215f78766ae7b1a66277e0033"},
-    {file = "traitlets-5.1.1.tar.gz", hash = "sha256:059f456c5a7c1c82b98c2e8c799f39c9b8128f6d0d46941ee118daace9eb70c7"},
-]
-"typed-ast 1.5.2" = [
-    {file = "typed_ast-1.5.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:183b183b7771a508395d2cbffd6db67d6ad52958a5fdc99f450d954003900266"},
-    {file = "typed_ast-1.5.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:676d051b1da67a852c0447621fdd11c4e104827417bf216092ec3e286f7da596"},
-    {file = "typed_ast-1.5.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bc2542e83ac8399752bc16e0b35e038bdb659ba237f4222616b4e83fb9654985"},
-    {file = "typed_ast-1.5.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:74cac86cc586db8dfda0ce65d8bcd2bf17b58668dfcc3652762f3ef0e6677e76"},
-    {file = "typed_ast-1.5.2-cp310-cp310-win_amd64.whl", hash = "sha256:18fe320f354d6f9ad3147859b6e16649a0781425268c4dde596093177660e71a"},
-    {file = "typed_ast-1.5.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:31d8c6b2df19a777bc8826770b872a45a1f30cfefcfd729491baa5237faae837"},
-    {file = "typed_ast-1.5.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:963a0ccc9a4188524e6e6d39b12c9ca24cc2d45a71cfdd04a26d883c922b4b78"},
-    {file = "typed_ast-1.5.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0eb77764ea470f14fcbb89d51bc6bbf5e7623446ac4ed06cbd9ca9495b62e36e"},
-    {file = "typed_ast-1.5.2-cp36-cp36m-win_amd64.whl", hash = "sha256:294a6903a4d087db805a7656989f613371915fc45c8cc0ddc5c5a0a8ad9bea4d"},
-    {file = "typed_ast-1.5.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:26a432dc219c6b6f38be20a958cbe1abffcc5492821d7e27f08606ef99e0dffd"},
-    {file = "typed_ast-1.5.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7407cfcad702f0b6c0e0f3e7ab876cd1d2c13b14ce770e412c0c4b9728a0f88"},
-    {file = "typed_ast-1.5.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f30ddd110634c2d7534b2d4e0e22967e88366b0d356b24de87419cc4410c41b7"},
-    {file = "typed_ast-1.5.2-cp37-cp37m-win_amd64.whl", hash = "sha256:8c08d6625bb258179b6e512f55ad20f9dfef019bbfbe3095247401e053a3ea30"},
-    {file = "typed_ast-1.5.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:90904d889ab8e81a956f2c0935a523cc4e077c7847a836abee832f868d5c26a4"},
-    {file = "typed_ast-1.5.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:bbebc31bf11762b63bf61aaae232becb41c5bf6b3461b80a4df7e791fabb3aca"},
-    {file = "typed_ast-1.5.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c29dd9a3a9d259c9fa19d19738d021632d673f6ed9b35a739f48e5f807f264fb"},
-    {file = "typed_ast-1.5.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:58ae097a325e9bb7a684572d20eb3e1809802c5c9ec7108e85da1eb6c1a3331b"},
-    {file = "typed_ast-1.5.2-cp38-cp38-win_amd64.whl", hash = "sha256:da0a98d458010bf4fe535f2d1e367a2e2060e105978873c04c04212fb20543f7"},
-    {file = "typed_ast-1.5.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:33b4a19ddc9fc551ebabca9765d54d04600c4a50eda13893dadf67ed81d9a098"},
-    {file = "typed_ast-1.5.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1098df9a0592dd4c8c0ccfc2e98931278a6c6c53cb3a3e2cf7e9ee3b06153344"},
-    {file = "typed_ast-1.5.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:42c47c3b43fe3a39ddf8de1d40dbbfca60ac8530a36c9b198ea5b9efac75c09e"},
-    {file = "typed_ast-1.5.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f290617f74a610849bd8f5514e34ae3d09eafd521dceaa6cf68b3f4414266d4e"},
-    {file = "typed_ast-1.5.2-cp39-cp39-win_amd64.whl", hash = "sha256:df05aa5b241e2e8045f5f4367a9f6187b09c4cdf8578bb219861c4e27c443db5"},
-    {file = "typed_ast-1.5.2.tar.gz", hash = "sha256:525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27"},
-]
-"typing-extensions 4.1.1" = [
-    {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},
-    {file = "typing_extensions-4.1.1.tar.gz", hash = "sha256:1a9462dcc3347a79b1f1c0271fbe79e844580bb598bafa1ed208b94da3cdcd42"},
-=======
-"tox-gh-actions 2.9.1" = [
-    {file = "tox_gh_actions-2.9.1-py2.py3-none-any.whl", hash = "sha256:90306a6a04a203e47f861b35dca215fc1f6b7ae80de942a050ace61e2eb2b4ea"},
-    {file = "tox-gh-actions-2.9.1.tar.gz", hash = "sha256:2bbb681eccd3fd3573231a05f7acf228caae1e3f12397b5517b404417ab90aba"},
-]
-||||||| parent of 6e0c75f (relock)
-"tox-gh-actions 2.9.1" = [
-    {file = "tox_gh_actions-2.9.1-py2.py3-none-any.whl", hash = "sha256:90306a6a04a203e47f861b35dca215fc1f6b7ae80de942a050ace61e2eb2b4ea"},
-    {file = "tox-gh-actions-2.9.1.tar.gz", hash = "sha256:2bbb681eccd3fd3573231a05f7acf228caae1e3f12397b5517b404417ab90aba"},
-]
-=======
->>>>>>> 6e0c75f (relock)
-"tox-pdm 0.5.0" = [
-    {file = "tox_pdm-0.5.0-py3-none-any.whl", hash = "sha256:0075ff9ed47ee13dc6e55122e6da121661a5553a633b8dd278013fbee81e4bb4"},
-    {file = "tox-pdm-0.5.0.tar.gz", hash = "sha256:45531c80c9670e7d9a0109ec5ab0d9add0492db4b41aa4ae0f20b295e4fd60e3"},
-]
-"traitlets 5.3.0" = [
-    {file = "traitlets-5.3.0-py3-none-any.whl", hash = "sha256:65fa18961659635933100db8ca120ef6220555286949774b9cfc106f941d1c7a"},
-    {file = "traitlets-5.3.0.tar.gz", hash = "sha256:0bb9f1f9f017aa8ec187d8b1b2a7a6626a2a1d877116baba52a129bfa124f8e2"},
-]
-"typed-ast 1.5.4" = [
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
-    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
-    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
-    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
-    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
-    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
-    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
-    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
-    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
-    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
-    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
-    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
-    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
-]
-"typing-extensions 4.2.0" = [
-    {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
-    {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
->>>>>>> 282c595 (Protocol type checking.)
 ]
 "urllib3 1.26.9" = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
     {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
 ]
-<<<<<<< HEAD
 "virtualenv 20.15.1" = [
     {file = "virtualenv-20.15.1-py2.py3-none-any.whl", hash = "sha256:b30aefac647e86af6d82bfc944c556f8f1a9c90427b2fb4e3bfbf338cb82becf"},
     {file = "virtualenv-20.15.1.tar.gz", hash = "sha256:288171134a2ff3bfb1a2f54f119e77cd1b81c29fc1265a2356f3e8d14c7d58c4"},
-||||||| parent of 282c595 (Protocol type checking.)
-"virtualenv 20.14.0" = [
-    {file = "virtualenv-20.14.0-py2.py3-none-any.whl", hash = "sha256:1e8588f35e8b42c6ec6841a13c5e88239de1e6e4e4cedfd3916b306dc826ec66"},
-    {file = "virtualenv-20.14.0.tar.gz", hash = "sha256:8e5b402037287126e81ccde9432b95a8be5b19d36584f64957060a3488c11ca8"},
-=======
-"virtualenv 20.15.0" = [
-    {file = "virtualenv-20.15.0-py2.py3-none-any.whl", hash = "sha256:804cce4de5b8a322f099897e308eecc8f6e2951f1a8e7e2b3598dff865f01336"},
-    {file = "virtualenv-20.15.0.tar.gz", hash = "sha256:4c44b1d77ca81f8368e2d7414f9b20c428ad16b343ac6d226206c5b84e2b4fcc"},
->>>>>>> 282c595 (Protocol type checking.)
 ]
 "wcwidth 0.2.5" = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dev = [
     "pytest-mypy~=0.8",
     "pandas~=1.1",
     "hypothesis~=6.21",
+<<<<<<< HEAD
     "tox-gh-actions~=2.8",
     "typing-extensions~=4.2",
 =======
@@ -73,6 +74,10 @@ dev = [
     "hypothesis~=6.21",
     "tox-gh-actions~=2.8",
 >>>>>>> 05d9ecd (relock)
+||||||| parent of 6e0c75f (relock)
+    "tox-gh-actions~=2.8",
+=======
+>>>>>>> 6e0c75f (relock)
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
 ]
 dependencies = [
     'colorama;platform_system=="Windows"',
-    'typing-extensions~=4.2',
+    'typing-extensions==4.2.*',
 ]
 requires-python = ">=3.7.1,<3.11"
 license = {text = "MIT"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ repository = "https://github.com/laike9m/pdir2"
 dev = [
     "pytest==6.2.*",
     "tox==3.24.*",
-    "tox-pdm==0.3.*",
+    "tox-pdm==0.5.*",
     "ptpython==3.0.*",
     "bpython==0.21.*",
     "ipython==7.16.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ repository = "https://github.com/laike9m/pdir2"
 [tool.pdm.dev-dependencies]
 dev = [
 <<<<<<< HEAD
+<<<<<<< HEAD
     "pytest==6.2.*",
     "tox==3.24.*",
     "tox-pdm==0.3.*",
@@ -78,6 +79,29 @@ dev = [
     "tox-gh-actions~=2.8",
 =======
 >>>>>>> 6e0c75f (relock)
+||||||| parent of 2dfc823 (fix dependencies version lock.)
+    "pytest~=6.2",
+    "tox~=3.24",
+    "tox-pdm~=0.3",
+    "ptpython~=3.0",
+    "bpython~=0.21",
+    "ipython~=7.16",
+    "flake8~=3.9",
+    "pytest-mypy~=0.8",
+    "pandas~=1.1",
+    "hypothesis~=6.21",
+=======
+    "pytest==6.2.*",
+    "tox==3.24.*",
+    "tox-pdm==0.3.*",
+    "ptpython==3.0.*",
+    "bpython==0.21.*",
+    "ipython==7.16.*",
+    "flake8==3.9.*",
+    "pytest-mypy==0.8.*",
+    "pandas==1.1.*",
+    "hypothesis==6.21.*",
+>>>>>>> 2dfc823 (fix dependencies version lock.)
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,6 @@ repository = "https://github.com/laike9m/pdir2"
 [project.optional-dependencies]
 [tool.pdm.dev-dependencies]
 dev = [
-<<<<<<< HEAD
-<<<<<<< HEAD
     "pytest==6.2.*",
     "tox==3.24.*",
     "tox-pdm==0.3.*",
@@ -48,60 +46,6 @@ dev = [
     "pandas==1.3.5",
     "hypothesis==6.21.*",
     "tox-gh-actions==2.8.*",
-||||||| parent of 05d9ecd (relock)
-    "pytest~=6.2",
-    "tox~=3.24",
-    "tox-pdm~=0.3",
-    "ptpython~=3.0",
-    "bpython~=0.21",
-    "ipython~=7.16",
-    "flake8~=3.9",
-    "pytest-mypy~=0.8",
-    "pandas~=1.1",
-    "hypothesis~=6.21",
-<<<<<<< HEAD
-    "tox-gh-actions~=2.8",
-    "typing-extensions~=4.2",
-=======
-    "pytest~=6.2",
-    "tox~=3.24",
-    "tox-pdm~=0.3",
-    "ptpython~=3.0",
-    "bpython~=0.21",
-    "ipython~=7.16",
-    "flake8~=3.9",
-    "pytest-mypy~=0.8",
-    "pandas~=1.1",
-    "hypothesis~=6.21",
-    "tox-gh-actions~=2.8",
->>>>>>> 05d9ecd (relock)
-||||||| parent of 6e0c75f (relock)
-    "tox-gh-actions~=2.8",
-=======
->>>>>>> 6e0c75f (relock)
-||||||| parent of 2dfc823 (fix dependencies version lock.)
-    "pytest~=6.2",
-    "tox~=3.24",
-    "tox-pdm~=0.3",
-    "ptpython~=3.0",
-    "bpython~=0.21",
-    "ipython~=7.16",
-    "flake8~=3.9",
-    "pytest-mypy~=0.8",
-    "pandas~=1.1",
-    "hypothesis~=6.21",
-=======
-    "pytest==6.2.*",
-    "tox==3.24.*",
-    "tox-pdm==0.3.*",
-    "ptpython==3.0.*",
-    "bpython==0.21.*",
-    "ipython==7.16.*",
-    "flake8==3.9.*",
-    "pytest-mypy==0.8.*",
-    "pandas==1.1.*",
-    "hypothesis==6.21.*",
->>>>>>> 2dfc823 (fix dependencies version lock.)
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ authors = [
 ]
 dependencies = [
     'colorama;platform_system=="Windows"',
+    'typing-extensions~=4.2',
 ]
 requires-python = ">=3.7.1,<3.11"
 license = {text = "MIT"}
@@ -34,6 +35,7 @@ repository = "https://github.com/laike9m/pdir2"
 [project.optional-dependencies]
 [tool.pdm.dev-dependencies]
 dev = [
+<<<<<<< HEAD
     "pytest==6.2.*",
     "tox==3.24.*",
     "tox-pdm==0.3.*",
@@ -45,6 +47,32 @@ dev = [
     "pandas==1.3.5",
     "hypothesis==6.21.*",
     "tox-gh-actions==2.8.*",
+||||||| parent of 05d9ecd (relock)
+    "pytest~=6.2",
+    "tox~=3.24",
+    "tox-pdm~=0.3",
+    "ptpython~=3.0",
+    "bpython~=0.21",
+    "ipython~=7.16",
+    "flake8~=3.9",
+    "pytest-mypy~=0.8",
+    "pandas~=1.1",
+    "hypothesis~=6.21",
+    "tox-gh-actions~=2.8",
+    "typing-extensions~=4.2",
+=======
+    "pytest~=6.2",
+    "tox~=3.24",
+    "tox-pdm~=0.3",
+    "ptpython~=3.0",
+    "bpython~=0.21",
+    "ipython~=7.16",
+    "flake8~=3.9",
+    "pytest-mypy~=0.8",
+    "pandas~=1.1",
+    "hypothesis~=6.21",
+    "tox-gh-actions~=2.8",
+>>>>>>> 05d9ecd (relock)
 ]
 
 [build-system]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,17 @@ from sys import modules
 PDIR2_CONFIG_FILE = "PDIR2_CONFIG_FILE"
 
 def remove_module_cache():
+    """
+    There are some global settings which are initialized when pdir firstly
+    import, then after that, no matter how you change the config or mock
+    ``isatty()`` functions, those global values (settings, mostly), will
+    not change.
+
+    So in order to make some of our patches or test configurations work, we
+    need to clear the import cache. So that when we ``import pdir`` in test
+    cases, those global values will be initialized again due to the lack of
+    cache.
+    """
     imported_modules = modules.keys()
     pdir_modules = [m for m in imported_modules if m.startswith('pdir')]
     for module in pdir_modules:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="session", autouse=True)
 def tty():
     with patch("sys.stdout.isatty") as faketty:
         faketty.return_value = True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,41 @@
+import os
 import pytest
 from unittest.mock import patch
+from sys import modules
 
-@pytest.fixture(scope="session", autouse=True)
+def remove_module_cache():
+    for module in (
+        'pdir',
+        'pdir.api',
+        'pdir.constants',
+        'pdir.format',
+        'pdir.configuration',
+        'pdir.color',
+        'pdir.utils',
+    ):
+        try:
+            del modules[module]
+        except KeyError:
+            pass
+
+
+@pytest.fixture
+def clean():
+    remove_module_cache()
+
+    DEFAULT_CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.pdir2config')
+    yield DEFAULT_CONFIG_FILE
+    if 'PDIR2_CONFIG_FILE' in os.environ:
+        if os.path.exists(os.environ['PDIR2_CONFIG_FILE']):
+            os.remove(os.environ['PDIR2_CONFIG_FILE'])
+        del os.environ['PDIR2_CONFIG_FILE']
+    if os.path.exists(DEFAULT_CONFIG_FILE):
+        os.remove(DEFAULT_CONFIG_FILE)
+
+
+@pytest.fixture(scope="session")
 def tty():
     with patch("sys.stdout.isatty") as faketty:
         faketty.return_value = True
+        remove_module_cache()
         yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,7 +22,7 @@ def remove_module_cache():
 
 
 @pytest.fixture
-def clean():
+def clean_cached_modules():
     remove_module_cache()
 
     DEFAULT_CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.pdir2config')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+import pytest
+from unittest.mock import patch
+
+@pytest.fixture(scope="session")
+def tty():
+    with patch("sys.stdout.isatty") as faketty:
+        faketty.return_value = True
+        yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,8 @@ import pytest
 from unittest.mock import patch
 from sys import modules
 
+PDIR2_CONFIG_FILE = "PDIR2_CONFIG_FILE"
+
 def remove_module_cache():
     for module in (
         'pdir',
@@ -25,16 +27,16 @@ def clean():
 
     DEFAULT_CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.pdir2config')
     yield DEFAULT_CONFIG_FILE
-    if 'PDIR2_CONFIG_FILE' in os.environ:
-        if os.path.exists(os.environ['PDIR2_CONFIG_FILE']):
-            os.remove(os.environ['PDIR2_CONFIG_FILE'])
-        del os.environ['PDIR2_CONFIG_FILE']
+    if PDIR2_CONFIG_FILE in os.environ:
+        if os.path.exists(os.environ[PDIR2_CONFIG_FILE]):
+            os.remove(os.environ[PDIR2_CONFIG_FILE])
+        del os.environ[PDIR2_CONFIG_FILE]
     if os.path.exists(DEFAULT_CONFIG_FILE):
         os.remove(DEFAULT_CONFIG_FILE)
 
 
 @pytest.fixture(scope="session")
-def tty():
+def enforce_tty_output():
     with patch("sys.stdout.isatty") as faketty:
         faketty.return_value = True
         remove_module_cache()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from sys import modules
 
 PDIR2_CONFIG_FILE = "PDIR2_CONFIG_FILE"
 
+
 def remove_module_cache():
     """
     There are some global settings which are initialized when pdir firstly
@@ -16,6 +17,8 @@ def remove_module_cache():
     need to clear the import cache. So that when we ``import pdir`` in test
     cases, those global values will be initialized again due to the lack of
     cache.
+
+    more detail: https://www.kawabangga.com/posts/4706 (Chinese)
     """
     imported_modules = modules.keys()
     pdir_modules = [m for m in imported_modules if m.startswith('pdir')]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,15 +6,9 @@ from sys import modules
 PDIR2_CONFIG_FILE = "PDIR2_CONFIG_FILE"
 
 def remove_module_cache():
-    for module in (
-        'pdir',
-        'pdir.api',
-        'pdir.constants',
-        'pdir.format',
-        'pdir.configuration',
-        'pdir.color',
-        'pdir.utils',
-    ):
+    imported_modules = modules.keys()
+    pdir_modules = [m for m in imported_modules if m.startswith('pdir')]
+    for module in pdir_modules:
         try:
             del modules[module]
         except KeyError:
@@ -36,7 +30,7 @@ def clean_cached_modules():
 
 
 @pytest.fixture(scope="session")
-def enforce_tty_output():
+def fake_tty():
     with patch("sys.stdout.isatty") as faketty:
         faketty.return_value = True
         remove_module_cache()

--- a/tests/data/config_auto_color.ini
+++ b/tests/data/config_auto_color.ini
@@ -1,0 +1,2 @@
+[global]
+colorful-output = auto

--- a/tests/data/config_auto_color.ini
+++ b/tests/data/config_auto_color.ini
@@ -1,2 +1,2 @@
 [global]
-colorful-output = auto
+enable-colorful-output = auto

--- a/tests/data/config_disable_color.ini
+++ b/tests/data/config_disable_color.ini
@@ -1,2 +1,2 @@
 [global]
-colorful-output = False
+enable-colorful-output = False

--- a/tests/data/config_disable_color.ini
+++ b/tests/data/config_disable_color.ini
@@ -1,0 +1,2 @@
+[global]
+colorful-output = False

--- a/tests/data/config_enable_color.ini
+++ b/tests/data/config_enable_color.ini
@@ -1,0 +1,2 @@
+[global]
+colorful-output = True

--- a/tests/data/config_enable_color.ini
+++ b/tests/data/config_enable_color.ini
@@ -1,2 +1,2 @@
 [global]
-colorful-output = True
+enable-colorful-output = True

--- a/tests/interactive_test.py
+++ b/tests/interactive_test.py
@@ -1,8 +1,3 @@
-import pdir
-from pdir._internal_utils import _get_repl_type
-from pdir.constants import ReplType
-
-
 def interactive_test():
     """
     This function runs pdir2 in bpython, ipython, ptpython.
@@ -10,6 +5,9 @@ def interactive_test():
     because print(string) is not equivalent to repr it in a REPL.
     To ensure everything truly works, manually verification is necessary.
     """
+    import pdir
+    from pdir._internal_utils import _get_repl_type
+    from pdir.constants import ReplType
     print('Environment: ' + _get_repl_type().value)
     import requests
 

--- a/tests/interactive_test.py
+++ b/tests/interactive_test.py
@@ -8,6 +8,7 @@ def interactive_test():
     import pdir
     from pdir._internal_utils import _get_repl_type
     from pdir.constants import ReplType
+
     print('Environment: ' + _get_repl_type().value)
     import requests
 

--- a/tests/test_buggy_attrs.py
+++ b/tests/test_buggy_attrs.py
@@ -8,6 +8,7 @@ import pytest
 def test_dataframe():
     import pdir
     from pdir.attr_category import AttrCategory, category_match
+
     pandas = pytest.importorskip("pandas")
 
     result = pdir(pandas.DataFrame)
@@ -19,6 +20,7 @@ def test_dataframe():
 def test_type():
     import pdir
     from pdir.attr_category import AttrCategory, category_match
+
     result = pdir(type)
     for attr in result.pattrs:
         if attr.name == '__abstractmethods__':
@@ -29,6 +31,7 @@ def test_type():
 def test_list():
     import pdir
     from pdir.attr_category import AttrCategory, category_match
+
     result = pdir(list)
     for attr in result.pattrs:
         if attr.name == 'append':
@@ -74,6 +77,7 @@ class RevealAccess:
 def test_descriptor():
     import pdir
     from pdir.attr_category import AttrCategory, category_match
+
     class T:
         r = RevealAccess(10, 'var ' r'')
 
@@ -127,6 +131,7 @@ def test_get_attribute_fail():
     """ "Tests if get_online_doc returns '' when __doc__ access throws an exception."""
 
     import pdir
+
     class DocAttributeFail:
         """Fails when __doc__ atribute is accessed."""
 

--- a/tests/test_buggy_attrs.py
+++ b/tests/test_buggy_attrs.py
@@ -3,10 +3,10 @@ Test attrs that previously caused bugs.
 """
 
 import pytest
+import pdir
 
 
 def test_dataframe():
-    import pdir
     from pdir.attr_category import AttrCategory, category_match
 
     pandas = pytest.importorskip("pandas")
@@ -18,7 +18,6 @@ def test_dataframe():
 
 
 def test_type():
-    import pdir
     from pdir.attr_category import AttrCategory, category_match
 
     result = pdir(type)
@@ -29,7 +28,6 @@ def test_type():
 
 
 def test_list():
-    import pdir
     from pdir.attr_category import AttrCategory, category_match
 
     result = pdir(list)
@@ -75,7 +73,6 @@ class RevealAccess:
 
 
 def test_descriptor():
-    import pdir
     from pdir.attr_category import AttrCategory, category_match
 
     class T:
@@ -114,7 +111,6 @@ def test_descriptor():
 
 
 def test_override_dir():
-    import pdir
 
     # In the class attrs in `__dir__()` can not be found in `__dict__`
     class ClassWithUserDefinedDir:
@@ -129,8 +125,6 @@ def test_override_dir():
 
 def test_get_attribute_fail():
     """ "Tests if get_online_doc returns '' when __doc__ access throws an exception."""
-
-    import pdir
 
     class DocAttributeFail:
         """Fails when __doc__ atribute is accessed."""

--- a/tests/test_buggy_attrs.py
+++ b/tests/test_buggy_attrs.py
@@ -4,13 +4,11 @@ Test attrs that previously caused bugs.
 
 import pytest
 import pdir
+from pdir.attr_category import AttrCategory, category_match
 
 
 def test_dataframe():
-    from pdir.attr_category import AttrCategory, category_match
-
     pandas = pytest.importorskip("pandas")
-
     result = pdir(pandas.DataFrame)
     for attr in result.pattrs:
         if attr.name in ('columns', 'index'):
@@ -18,8 +16,6 @@ def test_dataframe():
 
 
 def test_type():
-    from pdir.attr_category import AttrCategory, category_match
-
     result = pdir(type)
     for attr in result.pattrs:
         if attr.name == '__abstractmethods__':
@@ -28,8 +24,6 @@ def test_type():
 
 
 def test_list():
-    from pdir.attr_category import AttrCategory, category_match
-
     result = pdir(list)
     for attr in result.pattrs:
         if attr.name == 'append':
@@ -73,7 +67,6 @@ class RevealAccess:
 
 
 def test_descriptor():
-    from pdir.attr_category import AttrCategory, category_match
 
     class T:
         r = RevealAccess(10, 'var ' r'')

--- a/tests/test_buggy_attrs.py
+++ b/tests/test_buggy_attrs.py
@@ -4,11 +4,10 @@ Test attrs that previously caused bugs.
 
 import pytest
 
-import pdir
-from pdir.attr_category import AttrCategory, category_match
-
 
 def test_dataframe():
+    import pdir
+    from pdir.attr_category import AttrCategory, category_match
     pandas = pytest.importorskip("pandas")
 
     result = pdir(pandas.DataFrame)
@@ -18,6 +17,8 @@ def test_dataframe():
 
 
 def test_type():
+    import pdir
+    from pdir.attr_category import AttrCategory, category_match
     result = pdir(type)
     for attr in result.pattrs:
         if attr.name == '__abstractmethods__':
@@ -26,6 +27,8 @@ def test_type():
 
 
 def test_list():
+    import pdir
+    from pdir.attr_category import AttrCategory, category_match
     result = pdir(list)
     for attr in result.pattrs:
         if attr.name == 'append':
@@ -69,6 +72,8 @@ class RevealAccess:
 
 
 def test_descriptor():
+    import pdir
+    from pdir.attr_category import AttrCategory, category_match
     class T:
         r = RevealAccess(10, 'var ' r'')
 
@@ -105,6 +110,7 @@ def test_descriptor():
 
 
 def test_override_dir():
+    import pdir
 
     # In the class attrs in `__dir__()` can not be found in `__dict__`
     class ClassWithUserDefinedDir:
@@ -120,6 +126,7 @@ def test_override_dir():
 def test_get_attribute_fail():
     """ "Tests if get_online_doc returns '' when __doc__ access throws an exception."""
 
+    import pdir
     class DocAttributeFail:
         """Fails when __doc__ atribute is accessed."""
 

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,7 +1,5 @@
-import pdir
-
-
 def test_acting_like_a_list():
+    import pdir
     dadada = 1
     cadada = 1
     vadada = 1
@@ -15,6 +13,7 @@ def test_acting_like_a_list():
 
 
 def test_acting_like_a_list_when_search():
+    import pdir
     dadada = 1
     cadada = 1
     vadada = 1
@@ -26,6 +25,7 @@ def test_acting_like_a_list_when_search():
 
 
 def test_attr_order():
+    import pdir
     dir_attrs = dir(None)
     pdir_attrs = list(pdir(None))
     assert dir_attrs == pdir_attrs

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,7 @@
+import pdir
+
+
 def test_acting_like_a_list():
-    import pdir
 
     dadada = 1
     cadada = 1
@@ -14,7 +16,6 @@ def test_acting_like_a_list():
 
 
 def test_acting_like_a_list_when_search():
-    import pdir
 
     dadada = 1
     cadada = 1
@@ -27,7 +28,6 @@ def test_acting_like_a_list_when_search():
 
 
 def test_attr_order():
-    import pdir
 
     dir_attrs = dir(None)
     pdir_attrs = list(pdir(None))

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -1,5 +1,6 @@
 def test_acting_like_a_list():
     import pdir
+
     dadada = 1
     cadada = 1
     vadada = 1
@@ -14,6 +15,7 @@ def test_acting_like_a_list():
 
 def test_acting_like_a_list_when_search():
     import pdir
+
     dadada = 1
     cadada = 1
     vadada = 1
@@ -26,6 +28,7 @@ def test_acting_like_a_list_when_search():
 
 def test_attr_order():
     import pdir
+
     dir_attrs = dir(None)
     pdir_attrs = list(pdir(None))
     assert dir_attrs == pdir_attrs

--- a/tests/test_disbale_color.py
+++ b/tests/test_disbale_color.py
@@ -1,0 +1,9 @@
+def test_color_disabled():
+    from pdir.color import _ColorDisabled
+
+    c = _ColorDisabled()
+    assert c.wrap_text("foobar") == "foobar"
+
+    d = _ColorDisabled()
+    assert c == d
+    assert c is not d

--- a/tests/test_disbale_color.py
+++ b/tests/test_disbale_color.py
@@ -1,5 +1,7 @@
+from pdir.color import _ColorDisabled
+
+
 def test_color_disabled():
-    from pdir.color import _ColorDisabled
 
     c = _ColorDisabled()
     assert c.wrap_text("foobar") == "foobar"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -41,6 +41,7 @@ inst = DerivedClass()
 
 def test_properties():
     import pdir
+
     assert items_equal(
         [p.name for p in pdir(inst).properties.pattrs],
         [
@@ -59,6 +60,7 @@ def test_properties():
 
 def test_methods():
     import pdir
+
     if sys.version[0] == '2':
         assert items_equal(
             [p.name for p in pdir(inst).methods.pattrs],
@@ -113,6 +115,7 @@ def test_methods():
 
 def test_public():
     import pdir
+
     assert items_equal(
         [p.name for p in pdir(inst).public.pattrs],
         [
@@ -128,6 +131,7 @@ def test_public():
 
 def test_own():
     import pdir
+
     assert items_equal(
         [p.name for p in pdir(inst).own.pattrs],
         [
@@ -144,6 +148,7 @@ def test_own():
 
 def test_chained_filters():
     import pdir
+
     assert items_equal(
         [p.name for p in pdir(inst).public.own.properties.pattrs],
         [
@@ -156,6 +161,7 @@ def test_chained_filters():
 
 def test_order_of_chained_filters():
     import pdir
+
     assert items_equal(
         [p.name for p in pdir(inst).own.properties.public.pattrs],
         [
@@ -176,6 +182,7 @@ def test_order_of_chained_filters():
 
 def test_filters_with_search():
     import pdir
+
     def test_chained_filters():
         assert items_equal(
             [

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -5,8 +5,6 @@ Tests attribute filter's behaviors.
 import collections
 import sys
 
-import pdir
-
 
 # https://github.com/python/cpython/blob/da2bf9f66d0c95b988c5d87646d168f65499b316/Lib/unittest/case.py#L1164-L1195
 def items_equal(first, second):
@@ -42,6 +40,7 @@ inst = DerivedClass()
 
 
 def test_properties():
+    import pdir
     assert items_equal(
         [p.name for p in pdir(inst).properties.pattrs],
         [
@@ -59,6 +58,7 @@ def test_properties():
 
 
 def test_methods():
+    import pdir
     if sys.version[0] == '2':
         assert items_equal(
             [p.name for p in pdir(inst).methods.pattrs],
@@ -112,6 +112,7 @@ def test_methods():
 
 
 def test_public():
+    import pdir
     assert items_equal(
         [p.name for p in pdir(inst).public.pattrs],
         [
@@ -126,6 +127,7 @@ def test_public():
 
 
 def test_own():
+    import pdir
     assert items_equal(
         [p.name for p in pdir(inst).own.pattrs],
         [
@@ -141,6 +143,7 @@ def test_own():
 
 
 def test_chained_filters():
+    import pdir
     assert items_equal(
         [p.name for p in pdir(inst).public.own.properties.pattrs],
         [
@@ -152,6 +155,7 @@ def test_chained_filters():
 
 
 def test_order_of_chained_filters():
+    import pdir
     assert items_equal(
         [p.name for p in pdir(inst).own.properties.public.pattrs],
         [
@@ -171,6 +175,7 @@ def test_order_of_chained_filters():
 
 
 def test_filters_with_search():
+    import pdir
     def test_chained_filters():
         assert items_equal(
             [

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -4,6 +4,7 @@ Tests attribute filter's behaviors.
 
 import collections
 import sys
+import pdir
 
 
 # https://github.com/python/cpython/blob/da2bf9f66d0c95b988c5d87646d168f65499b316/Lib/unittest/case.py#L1164-L1195
@@ -40,7 +41,6 @@ inst = DerivedClass()
 
 
 def test_properties():
-    import pdir
 
     assert items_equal(
         [p.name for p in pdir(inst).properties.pattrs],
@@ -59,7 +59,6 @@ def test_properties():
 
 
 def test_methods():
-    import pdir
 
     if sys.version[0] == '2':
         assert items_equal(
@@ -114,7 +113,6 @@ def test_methods():
 
 
 def test_public():
-    import pdir
 
     assert items_equal(
         [p.name for p in pdir(inst).public.pattrs],
@@ -130,7 +128,6 @@ def test_public():
 
 
 def test_own():
-    import pdir
 
     assert items_equal(
         [p.name for p in pdir(inst).own.pattrs],
@@ -147,7 +144,6 @@ def test_own():
 
 
 def test_chained_filters():
-    import pdir
 
     assert items_equal(
         [p.name for p in pdir(inst).public.own.properties.pattrs],
@@ -160,7 +156,6 @@ def test_chained_filters():
 
 
 def test_order_of_chained_filters():
-    import pdir
 
     assert items_equal(
         [p.name for p in pdir(inst).own.properties.public.pattrs],
@@ -181,8 +176,6 @@ def test_order_of_chained_filters():
 
 
 def test_filters_with_search():
-    import pdir
-
     def test_chained_filters():
         assert items_equal(
             [

--- a/tests/test_pdir_format.py
+++ b/tests/test_pdir_format.py
@@ -1,18 +1,16 @@
 import sys
-
-import pdir
 import pytest
-from pdir._internal_utils import get_first_sentence_of_docstring
-from pdir.attr_category import AttrCategory
-from pdir.format import _FORMATTER
 
 
 def test_formatter_integrity():
+    from pdir.attr_category import AttrCategory
+    from pdir.format import _FORMATTER
     for ac in AttrCategory:
         assert ac in _FORMATTER
 
 
-def test_pdir_module():
+def test_pdir_module(tty):
+    import pdir
     import m
 
     result = pdir(m)
@@ -78,7 +76,8 @@ def test_pdir_module():
     del m
 
 
-def test_pdir_object():
+def test_pdir_object(tty):
+    import pdir
     class T:
         def what(self):
             """doc line"""
@@ -94,7 +93,8 @@ def test_pdir_object():
         sys.version_info
     ),
 )
-def test_pdir_class():
+def test_pdir_class(tty):
+    import pdir
     class T:
         pass
 
@@ -187,7 +187,8 @@ def test_pdir_class():
     print(result)
 
 
-def test_dir_without_argument():
+def test_dir_without_argument(tty):
+    import pdir
     a = 1
     b = 2
 
@@ -208,7 +209,8 @@ def test_dir_without_argument():
     print(result)
 
 
-def test_slots():
+def test_slots(tty):
+    import pdir
     class A:
         __slots__ = ['__mul__', '__hash__', 'a', 'b']
 
@@ -345,6 +347,7 @@ def test_slots():
     ],
 )
 def test_get_first_line_of_docstring(docstring, first_line):
+    from pdir._internal_utils import get_first_sentence_of_docstring
     CustomClass = type('CustomClass', (object,), {})
     setattr(CustomClass, '__doc__', docstring)
     assert get_first_sentence_of_docstring(CustomClass) == first_line

--- a/tests/test_pdir_format.py
+++ b/tests/test_pdir_format.py
@@ -2,9 +2,10 @@ import sys
 import pytest
 
 
-def test_formatter_integrity():
+def test_formatter_integrity(tty):
     from pdir.attr_category import AttrCategory
     from pdir.format import _FORMATTER
+
     for ac in AttrCategory:
         assert ac in _FORMATTER
 
@@ -78,6 +79,7 @@ def test_pdir_module(tty):
 
 def test_pdir_object(tty):
     import pdir
+
     class T:
         def what(self):
             """doc line"""
@@ -95,6 +97,7 @@ def test_pdir_object(tty):
 )
 def test_pdir_class(tty):
     import pdir
+
     class T:
         pass
 
@@ -189,6 +192,7 @@ def test_pdir_class(tty):
 
 def test_dir_without_argument(tty):
     import pdir
+
     a = 1
     b = 2
 
@@ -200,10 +204,11 @@ def test_dir_without_argument(tty):
     assert repr(result) == '\n'.join(
         [
             '\x1b[0;33mproperty:\x1b[0m',
-            '    \x1b[0;36ma\x1b[0m\x1b[1;30m, \x1b[0m\x1b[0;36mb\x1b[0m',
+            '    \x1b[0;36ma\x1b[0m\x1b[1;30m, \x1b[0m\x1b[0;36mb\x1b[0m\x1b[1;30m, \x1b[0m\x1b[0;36mtty\x1b[0m',
+            '\x1b[0;33mclass:\x1b[0m',
+            '    \x1b[0;36mpdir\x1b[0m\x1b[0;36m: \x1b[0m\x1b[1;30mClass that provides pretty dir and search API.\x1b[0m',
             '\x1b[0;33mfunction:\x1b[0m',
-            '    \x1b[0;36mwhatever\x1b[0m\x1b[0;36m: \x1b[0m\x1b'
-            '[1;30mOne line doc.\x1b[0m',
+            '    \x1b[0;36mwhatever\x1b[0m\x1b[0;36m: \x1b[0m\x1b[1;30mOne line doc.\x1b[0m',
         ]
     )
     print(result)
@@ -211,6 +216,7 @@ def test_dir_without_argument(tty):
 
 def test_slots(tty):
     import pdir
+
     class A:
         __slots__ = ['__mul__', '__hash__', 'a', 'b']
 
@@ -346,8 +352,9 @@ def test_slots(tty):
         ('Return a.b as\nresult', 'Return a.b as result'),
     ],
 )
-def test_get_first_line_of_docstring(docstring, first_line):
+def test_get_first_line_of_docstring(docstring, first_line, tty):
     from pdir._internal_utils import get_first_sentence_of_docstring
+
     CustomClass = type('CustomClass', (object,), {})
     setattr(CustomClass, '__doc__', docstring)
     assert get_first_sentence_of_docstring(CustomClass) == first_line

--- a/tests/test_pdir_format.py
+++ b/tests/test_pdir_format.py
@@ -2,7 +2,7 @@ import sys
 import pytest
 
 
-def test_formatter_integrity(tty):
+def test_formatter_integrity(fake_tty):
     from pdir.attr_category import AttrCategory
     from pdir.format import _FORMATTER
 
@@ -10,7 +10,7 @@ def test_formatter_integrity(tty):
         assert ac in _FORMATTER
 
 
-def test_pdir_module(tty):
+def test_pdir_module(fake_tty):
     import pdir
     import m
 
@@ -77,7 +77,7 @@ def test_pdir_module(tty):
     del m
 
 
-def test_pdir_object(tty):
+def test_pdir_object(fake_tty):
     import pdir
 
     class T:
@@ -95,7 +95,7 @@ def test_pdir_object(tty):
         sys.version_info
     ),
 )
-def test_pdir_class(tty):
+def test_pdir_class(fake_tty):
     import pdir
 
     class T:
@@ -190,7 +190,7 @@ def test_pdir_class(tty):
     print(result)
 
 
-def test_dir_without_argument(tty):
+def test_dir_without_argument(fake_tty):
     import pdir
 
     a = 1
@@ -214,7 +214,7 @@ def test_dir_without_argument(tty):
     print(result)
 
 
-def test_slots(tty):
+def test_slots(fake_tty):
     import pdir
 
     class A:

--- a/tests/test_pdir_format.py
+++ b/tests/test_pdir_format.py
@@ -204,7 +204,7 @@ def test_dir_without_argument(fake_tty):
     assert repr(result) == '\n'.join(
         [
             '\x1b[0;33mproperty:\x1b[0m',
-            '    \x1b[0;36ma\x1b[0m\x1b[1;30m, \x1b[0m\x1b[0;36mb\x1b[0m\x1b[1;30m, \x1b[0m\x1b[0;36mtty\x1b[0m',
+            '    \x1b[0;36ma\x1b[0m\x1b[1;30m, \x1b[0m\x1b[0;36mb\x1b[0m\x1b[1;30m, \x1b[0m\x1b[0;36mfake_tty\x1b[0m',
             '\x1b[0;33mclass:\x1b[0m',
             '    \x1b[0;36mpdir\x1b[0m\x1b[0;36m: \x1b[0m\x1b[1;30mClass that provides pretty dir and search API.\x1b[0m',
             '\x1b[0;33mfunction:\x1b[0m',
@@ -352,7 +352,7 @@ def test_slots(fake_tty):
         ('Return a.b as\nresult', 'Return a.b as result'),
     ],
 )
-def test_get_first_line_of_docstring(docstring, first_line, tty):
+def test_get_first_line_of_docstring(docstring, first_line, fake_tty):
     from pdir._internal_utils import get_first_sentence_of_docstring
 
     CustomClass = type('CustomClass', (object,), {})

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,5 +1,6 @@
 def test_search_without_argument(fake_tty):
     import pdir
+
     foo = 1
     bar = 1
     baz = 1
@@ -20,6 +21,7 @@ def test_search_without_argument(fake_tty):
 
 def test_search_with_argument(fake_tty):
     import pdir
+
     class T:
         pass
 

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,4 +1,4 @@
-def test_search_without_argument(tty):
+def test_search_without_argument(fake_tty):
     import pdir
     foo = 1
     bar = 1
@@ -18,7 +18,7 @@ def test_search_without_argument(tty):
     )
 
 
-def test_search_with_argument(tty):
+def test_search_with_argument(fake_tty):
     import pdir
     class T:
         pass

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -1,7 +1,5 @@
-import pdir
-
-
-def test_search_without_argument():
+def test_search_without_argument(tty):
+    import pdir
     foo = 1
     bar = 1
     baz = 1
@@ -20,7 +18,8 @@ def test_search_without_argument():
     )
 
 
-def test_search_with_argument():
+def test_search_with_argument(tty):
+    import pdir
     class T:
         pass
 

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -4,9 +4,6 @@ Test classes with __slots__
 
 from typing import List
 
-import pdir
-from pdir.attr_category import AttrCategory, category_match
-
 
 BASE = 'base'
 DERIVE = 'derive'
@@ -57,6 +54,8 @@ class DeriveSlotBaseSlot(BaseSlot):
 
 
 def test_not_set():
+    import pdir
+    from pdir.attr_category import AttrCategory, category_match
     expected_res = [  # class type    empty slot attr num
         (DeriveNoSlotBaseEmpty, 0),
         (DeriveNoSlotBaseSlot, 1),
@@ -78,6 +77,8 @@ def test_not_set():
 
 
 def test_set_derive():
+    import pdir
+    from pdir.attr_category import AttrCategory, category_match
     c_types = [DeriveSlotBaseNo, DeriveSlotBaseEmpty, DeriveSlotBaseSlot]
     for c_type in c_types:
         instance = c_type()
@@ -93,6 +94,8 @@ def test_set_derive():
 
 
 def test_set_base():
+    import pdir
+    from pdir.attr_category import AttrCategory, category_match
     c_types = [DeriveNoSlotBaseSlot, DeriveEmptySlotBaseSlot, DeriveSlotBaseSlot]
     for c_type in c_types:
         instance = c_type()

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -3,6 +3,8 @@ Test classes with __slots__
 """
 
 from typing import List
+import pdir
+from pdir.attr_category import AttrCategory, category_match
 
 
 BASE = 'base'
@@ -54,8 +56,6 @@ class DeriveSlotBaseSlot(BaseSlot):
 
 
 def test_not_set():
-    import pdir
-    from pdir.attr_category import AttrCategory, category_match
 
     expected_res = [  # class type    empty slot attr num
         (DeriveNoSlotBaseEmpty, 0),
@@ -78,8 +78,6 @@ def test_not_set():
 
 
 def test_set_derive():
-    import pdir
-    from pdir.attr_category import AttrCategory, category_match
 
     c_types = [DeriveSlotBaseNo, DeriveSlotBaseEmpty, DeriveSlotBaseSlot]
     for c_type in c_types:
@@ -96,8 +94,6 @@ def test_set_derive():
 
 
 def test_set_base():
-    import pdir
-    from pdir.attr_category import AttrCategory, category_match
 
     c_types = [DeriveNoSlotBaseSlot, DeriveEmptySlotBaseSlot, DeriveSlotBaseSlot]
     for c_type in c_types:

--- a/tests/test_slots.py
+++ b/tests/test_slots.py
@@ -56,6 +56,7 @@ class DeriveSlotBaseSlot(BaseSlot):
 def test_not_set():
     import pdir
     from pdir.attr_category import AttrCategory, category_match
+
     expected_res = [  # class type    empty slot attr num
         (DeriveNoSlotBaseEmpty, 0),
         (DeriveNoSlotBaseSlot, 1),
@@ -79,6 +80,7 @@ def test_not_set():
 def test_set_derive():
     import pdir
     from pdir.attr_category import AttrCategory, category_match
+
     c_types = [DeriveSlotBaseNo, DeriveSlotBaseEmpty, DeriveSlotBaseSlot]
     for c_type in c_types:
         instance = c_type()
@@ -96,6 +98,7 @@ def test_set_derive():
 def test_set_base():
     import pdir
     from pdir.attr_category import AttrCategory, category_match
+
     c_types = [DeriveNoSlotBaseSlot, DeriveEmptySlotBaseSlot, DeriveSlotBaseSlot]
     for c_type in c_types:
         instance = c_type()

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -4,44 +4,17 @@ Test user configuration.
 
 import os
 import shutil
-from sys import modules
 
 import pytest
 
 
-@pytest.fixture
-def clean():
-    for module in (
-        'pdir',
-        'pdir.api',
-        'pdir.constants',
-        'pdir.format',
-        'pdir.configuration',
-        'pdir.color',
-        'pdir.utils',
-    ):
-        try:
-            del modules[module]
-        except KeyError:
-            pass
-
-    DEFAULT_CONFIG_FILE = os.path.join(os.path.expanduser('~'), '.pdir2config')
-    yield DEFAULT_CONFIG_FILE
-    if 'PDIR2_CONFIG_FILE' in os.environ:
-        if os.path.exists(os.environ['PDIR2_CONFIG_FILE']):
-            os.remove(os.environ['PDIR2_CONFIG_FILE'])
-        del os.environ['PDIR2_CONFIG_FILE']
-    if os.path.exists(DEFAULT_CONFIG_FILE):
-        os.remove(DEFAULT_CONFIG_FILE)
-
-
-def test_default_env_without_config(clean):
+def test_default_env_without_config(tty, clean):
     import pdir
 
     pdir()
 
 
-def test_set_env_without_config(clean):
+def test_set_env_without_config(tty, clean):
     os.environ['PDIR2_CONFIG_FILE'] = 'aaa'
     with pytest.raises(OSError, match='Config file not exist: aaa'):
         import pdir
@@ -49,7 +22,7 @@ def test_set_env_without_config(clean):
         pdir()
 
 
-def test_read_config(clean):
+def test_read_config(tty, clean):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
     shutil.copyfile('tests/data/config_1.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
@@ -61,7 +34,51 @@ def test_read_config(clean):
     assert attribute_color == COLORS['cyan']
 
 
-def test_read_config_from_custom_location(clean):
+def test_config_disable_color_tty(tty, clean):
+    # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
+    shutil.copyfile('tests/data/config_disable_color.ini', clean)
+    from pdir.format import doc_color, category_color, attribute_color, comma
+    from pdir.color import COLOR_DISABLED
+
+    assert doc_color == COLOR_DISABLED
+    assert category_color == COLOR_DISABLED
+    assert comma == ', '
+    assert attribute_color == COLOR_DISABLED
+
+
+def test_config_auto_color_tty(tty, clean):
+    # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
+    shutil.copyfile('tests/data/config_auto_color.ini', clean)
+    from pdir.format import doc_color
+    from pdir.color import COLORS
+
+    assert doc_color == COLORS['grey']
+
+
+def test_config_enable_color_not_tty(clean):
+    # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
+    shutil.copyfile('tests/data/config_enable_color.ini', clean)
+    from pdir.format import doc_color
+    from pdir.color import COLORS
+
+    assert doc_color == COLORS['grey']
+
+
+def test_env_disable_color_even_config_set(tty, clean):
+    shutil.copyfile('tests/data/config_enable_color.ini', clean)
+    os.environ['PDIR2_NOCOLOR'] = "true"
+    from pdir.format import doc_color, category_color, attribute_color, comma
+    from pdir.color import COLOR_DISABLED
+
+    assert doc_color == COLOR_DISABLED
+    assert category_color == COLOR_DISABLED
+    assert comma == ', '
+    assert attribute_color == COLOR_DISABLED
+
+    del os.environ['PDIR2_NOCOLOR']
+
+
+def test_read_config_from_custom_location(tty, clean):
     os.environ['PDIR2_CONFIG_FILE'] = os.path.join(os.path.expanduser('~'), '.myconfig')
     shutil.copyfile('tests/data/config_1.ini', os.environ['PDIR2_CONFIG_FILE'])
     from pdir.format import doc_color, category_color, attribute_color, comma
@@ -73,7 +90,7 @@ def test_read_config_from_custom_location(clean):
     assert attribute_color == COLORS['cyan']
 
 
-def test_uniform_color(clean):
+def test_uniform_color(tty, clean):
     shutil.copyfile('tests/data/config_2.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLORS
@@ -84,7 +101,7 @@ def test_uniform_color(clean):
     assert attribute_color == COLORS['white']
 
 
-def test_empty_config(clean):
+def test_empty_config(tty, clean):
     shutil.copyfile('tests/data/empty_config.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLORS

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -7,7 +7,6 @@ import shutil
 from sys import modules
 
 import pytest
-from pdir.color import COLORS
 
 
 @pytest.fixture
@@ -54,6 +53,7 @@ def test_read_config(clean):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
     shutil.copyfile('tests/data/config_1.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
+    from pdir.color import COLORS
 
     assert doc_color == COLORS['white']
     assert category_color == COLORS['bright yellow']
@@ -65,6 +65,7 @@ def test_read_config_from_custom_location(clean):
     os.environ['PDIR2_CONFIG_FILE'] = os.path.join(os.path.expanduser('~'), '.myconfig')
     shutil.copyfile('tests/data/config_1.ini', os.environ['PDIR2_CONFIG_FILE'])
     from pdir.format import doc_color, category_color, attribute_color, comma
+    from pdir.color import COLORS
 
     assert doc_color == COLORS['white']
     assert category_color == COLORS['bright yellow']
@@ -75,6 +76,7 @@ def test_read_config_from_custom_location(clean):
 def test_uniform_color(clean):
     shutil.copyfile('tests/data/config_2.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
+    from pdir.color import COLORS
 
     assert doc_color == COLORS['white']
     assert category_color == COLORS['white']
@@ -85,6 +87,7 @@ def test_uniform_color(clean):
 def test_empty_config(clean):
     shutil.copyfile('tests/data/empty_config.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
+    from pdir.color import COLORS
 
     assert doc_color == COLORS['grey']
     assert category_color == COLORS['yellow']

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -8,13 +8,13 @@ import shutil
 import pytest
 
 
-def test_default_env_without_config(tty, clean):
+def test_default_env_without_config(fake_tty, clean):
     import pdir
 
     pdir()
 
 
-def test_set_env_without_config(tty, clean):
+def test_set_env_without_config(fake_tty, clean):
     os.environ['PDIR2_CONFIG_FILE'] = 'aaa'
     with pytest.raises(OSError, match='Config file not exist: aaa'):
         import pdir
@@ -22,7 +22,7 @@ def test_set_env_without_config(tty, clean):
         pdir()
 
 
-def test_read_config(tty, clean):
+def test_read_config(fake_tty, clean):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
     shutil.copyfile('tests/data/config_1.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
@@ -34,7 +34,7 @@ def test_read_config(tty, clean):
     assert attribute_color == COLORS['cyan']
 
 
-def test_config_disable_color_tty(tty, clean):
+def test_config_disable_color_tty(fake_tty, clean):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
     shutil.copyfile('tests/data/config_disable_color.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
@@ -46,7 +46,7 @@ def test_config_disable_color_tty(tty, clean):
     assert attribute_color == COLOR_DISABLED
 
 
-def test_config_auto_color_tty(tty, clean):
+def test_config_auto_color_tty(fake_tty, clean):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
     shutil.copyfile('tests/data/config_auto_color.ini', clean)
     from pdir.format import doc_color
@@ -64,7 +64,7 @@ def test_config_enable_color_not_tty(clean):
     assert doc_color == COLORS['grey']
 
 
-def test_env_disable_color_even_config_set(tty, clean):
+def test_env_disable_color_even_config_set(fake_tty, clean):
     shutil.copyfile('tests/data/config_enable_color.ini', clean)
     os.environ['PDIR2_NOCOLOR'] = "true"
     from pdir.format import doc_color, category_color, attribute_color, comma
@@ -78,7 +78,7 @@ def test_env_disable_color_even_config_set(tty, clean):
     del os.environ['PDIR2_NOCOLOR']
 
 
-def test_read_config_from_custom_location(tty, clean):
+def test_read_config_from_custom_location(fake_tty, clean):
     os.environ['PDIR2_CONFIG_FILE'] = os.path.join(os.path.expanduser('~'), '.myconfig')
     shutil.copyfile('tests/data/config_1.ini', os.environ['PDIR2_CONFIG_FILE'])
     from pdir.format import doc_color, category_color, attribute_color, comma
@@ -90,7 +90,7 @@ def test_read_config_from_custom_location(tty, clean):
     assert attribute_color == COLORS['cyan']
 
 
-def test_uniform_color(tty, clean):
+def test_uniform_color(fake_tty, clean):
     shutil.copyfile('tests/data/config_2.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLORS
@@ -101,7 +101,7 @@ def test_uniform_color(tty, clean):
     assert attribute_color == COLORS['white']
 
 
-def test_empty_config(tty, clean):
+def test_empty_config(fake_tty, clean):
     shutil.copyfile('tests/data/empty_config.ini', clean)
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLORS

--- a/tests/test_user_config.py
+++ b/tests/test_user_config.py
@@ -8,13 +8,13 @@ import shutil
 import pytest
 
 
-def test_default_env_without_config(fake_tty, clean):
+def test_default_env_without_config(fake_tty, clean_cached_modules):
     import pdir
 
     pdir()
 
 
-def test_set_env_without_config(fake_tty, clean):
+def test_set_env_without_config(fake_tty, clean_cached_modules):
     os.environ['PDIR2_CONFIG_FILE'] = 'aaa'
     with pytest.raises(OSError, match='Config file not exist: aaa'):
         import pdir
@@ -22,9 +22,9 @@ def test_set_env_without_config(fake_tty, clean):
         pdir()
 
 
-def test_read_config(fake_tty, clean):
+def test_read_config(fake_tty, clean_cached_modules):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
-    shutil.copyfile('tests/data/config_1.ini', clean)
+    shutil.copyfile('tests/data/config_1.ini', clean_cached_modules)
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLORS
 
@@ -34,9 +34,9 @@ def test_read_config(fake_tty, clean):
     assert attribute_color == COLORS['cyan']
 
 
-def test_config_disable_color_tty(fake_tty, clean):
+def test_config_disable_color_tty(fake_tty, clean_cached_modules):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
-    shutil.copyfile('tests/data/config_disable_color.ini', clean)
+    shutil.copyfile('tests/data/config_disable_color.ini', clean_cached_modules)
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLOR_DISABLED
 
@@ -46,26 +46,26 @@ def test_config_disable_color_tty(fake_tty, clean):
     assert attribute_color == COLOR_DISABLED
 
 
-def test_config_auto_color_tty(fake_tty, clean):
+def test_config_auto_color_tty(fake_tty, clean_cached_modules):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
-    shutil.copyfile('tests/data/config_auto_color.ini', clean)
+    shutil.copyfile('tests/data/config_auto_color.ini', clean_cached_modules)
     from pdir.format import doc_color
     from pdir.color import COLORS
 
     assert doc_color == COLORS['grey']
 
 
-def test_config_enable_color_not_tty(clean):
+def test_config_enable_color_not_tty(clean_cached_modules):
     # 'clean' is the DEFAULT_CONFIG_FILE yielded from fixture.
-    shutil.copyfile('tests/data/config_enable_color.ini', clean)
+    shutil.copyfile('tests/data/config_enable_color.ini', clean_cached_modules)
     from pdir.format import doc_color
     from pdir.color import COLORS
 
     assert doc_color == COLORS['grey']
 
 
-def test_env_disable_color_even_config_set(fake_tty, clean):
-    shutil.copyfile('tests/data/config_enable_color.ini', clean)
+def test_env_disable_color_even_config_set(fake_tty, clean_cached_modules):
+    shutil.copyfile('tests/data/config_enable_color.ini', clean_cached_modules)
     os.environ['PDIR2_NOCOLOR'] = "true"
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLOR_DISABLED
@@ -78,7 +78,7 @@ def test_env_disable_color_even_config_set(fake_tty, clean):
     del os.environ['PDIR2_NOCOLOR']
 
 
-def test_read_config_from_custom_location(fake_tty, clean):
+def test_read_config_from_custom_location(fake_tty, clean_cached_modules):
     os.environ['PDIR2_CONFIG_FILE'] = os.path.join(os.path.expanduser('~'), '.myconfig')
     shutil.copyfile('tests/data/config_1.ini', os.environ['PDIR2_CONFIG_FILE'])
     from pdir.format import doc_color, category_color, attribute_color, comma
@@ -90,8 +90,8 @@ def test_read_config_from_custom_location(fake_tty, clean):
     assert attribute_color == COLORS['cyan']
 
 
-def test_uniform_color(fake_tty, clean):
-    shutil.copyfile('tests/data/config_2.ini', clean)
+def test_uniform_color(fake_tty, clean_cached_modules):
+    shutil.copyfile('tests/data/config_2.ini', clean_cached_modules)
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLORS
 
@@ -101,8 +101,8 @@ def test_uniform_color(fake_tty, clean):
     assert attribute_color == COLORS['white']
 
 
-def test_empty_config(fake_tty, clean):
-    shutil.copyfile('tests/data/empty_config.ini', clean)
+def test_empty_config(fake_tty, clean_cached_modules):
+    shutil.copyfile('tests/data/empty_config.ini', clean_cached_modules)
     from pdir.format import doc_color, category_color, attribute_color, comma
     from pdir.color import COLORS
 
@@ -112,16 +112,16 @@ def test_empty_config(fake_tty, clean):
     assert attribute_color == COLORS['cyan']
 
 
-def test_invalid_config_1(clean):
-    shutil.copyfile('tests/data/error_config_1.ini', clean)
+def test_invalid_config_1(clean_cached_modules):
+    shutil.copyfile('tests/data/error_config_1.ini', clean_cached_modules)
     with pytest.raises(ValueError, match='Invalid key: doc-color1'):
         import pdir
 
         pdir()
 
 
-def test_invalid_config_2(clean):
-    shutil.copyfile('tests/data/error_config_2.ini', clean)
+def test_invalid_config_2(clean_cached_modules):
+    shutil.copyfile('tests/data/error_config_2.ini', clean_cached_modules)
     with pytest.raises(ValueError, match='Invalid color value: 42'):
         import pdir
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
 envlist = py37,py38,py39,py310,extra,mypy
+isolated_build = True
 
 [gh-actions]
 python =


### PR DESCRIPTION
You can disable color output by setting `colorful-output = False` in `~/.pdir2config` now.

Example:

```
[global]
colorful-output = True
```

`True` means always use color, `False` means always disable color, and `auto` means using color output when stdout is a TTY, otherwise not.

You can also disable colors by environment variable `export PDIR2_NOCOLOR=1`. The environment has higher priority than the config file.

close #65 