### PR TITLE
Cache __pypackages__ in Github Action to speed up CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,26 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Cache pypackages
+        uses: actions/cache@v2
+        with:
+          path: __pypackages__
+          key: pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
+          restore-keys: |
+            pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
+
+      - name: Cache tox pypackages
+        uses: actions/cache@v2
+        with:
+          path: .tox/**/__pypackages__
+          key: tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-${{ hashFiles('pdm.lock') }}
+          restore-keys: |
+            tox-pypackages-${{ matrix.os }}-${{ matrix.python-version }}-
+
       - name: Install dependencies
         run: pdm install -v
         # On Windows, interactive test doesn't work, so exclude it.
+
       - name: Run tests
         run: pdm run tox -v
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -222,13 +222,16 @@ dependencies = [
 
 [[package]]
 name = "pandas"
-version = "1.1.5"
-requires_python = ">=3.6.1"
+version = "1.3.5"
+requires_python = ">=3.7.1"
 summary = "Powerful data structures for data analysis, time series, and statistics"
 dependencies = [
-    "numpy>=1.15.4",
+    "numpy>=1.17.3; platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\"",
+    "numpy>=1.19.2; platform_machine == \"aarch64\" and python_version < \"3.10\"",
+    "numpy>=1.20.0; platform_machine == \"arm64\" and python_version < \"3.10\"",
+    "numpy>=1.21.0; python_version >= \"3.10\"",
     "python-dateutil>=2.7.3",
-    "pytz>=2017.2",
+    "pytz>=2017.3",
 ]
 
 [[package]]
@@ -415,7 +418,7 @@ summary = "A lil' TOML parser"
 
 [[package]]
 name = "tox"
-version = "3.25.0"
+version = "3.24.5"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "tox is a generic virtualenv management and test command line tool"
 dependencies = [
@@ -871,9 +874,9 @@ content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe63292
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-"tox 3.25.0" = [
-    {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
-    {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
+"tox 3.24.5" = [
+    {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
+    {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
 ]
 "tox-gh-actions 2.8.1" = [
     {file = "tox_gh_actions-2.8.1-py2.py3-none-any.whl", hash = "sha256:9d22215a487f3c2f61ba0af5454010009b23fecf0a909b4a831a20d641a77369"},

--- a/pdm.lock
+++ b/pdm.lock
@@ -222,16 +222,13 @@ dependencies = [
 
 [[package]]
 name = "pandas"
-version = "1.3.5"
-requires_python = ">=3.7.1"
+version = "1.1.5"
+requires_python = ">=3.6.1"
 summary = "Powerful data structures for data analysis, time series, and statistics"
 dependencies = [
-    "numpy>=1.17.3; platform_machine != \"aarch64\" and platform_machine != \"arm64\" and python_version < \"3.10\"",
-    "numpy>=1.19.2; platform_machine == \"aarch64\" and python_version < \"3.10\"",
-    "numpy>=1.20.0; platform_machine == \"arm64\" and python_version < \"3.10\"",
-    "numpy>=1.21.0; python_version >= \"3.10\"",
+    "numpy>=1.15.4",
     "python-dateutil>=2.7.3",
-    "pytz>=2017.3",
+    "pytz>=2017.2",
 ]
 
 [[package]]
@@ -418,7 +415,7 @@ summary = "A lil' TOML parser"
 
 [[package]]
 name = "tox"
-version = "3.24.5"
+version = "3.25.0"
 requires_python = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 summary = "tox is a generic virtualenv management and test command line tool"
 dependencies = [
@@ -874,9 +871,9 @@ content_hash = "sha256:cd6b73ee92b22db86f99dc7186253be4d488b7a5c95aeab3a4fe63292
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-"tox 3.24.5" = [
-    {file = "tox-3.24.5-py2.py3-none-any.whl", hash = "sha256:be3362472a33094bce26727f5f771ca0facf6dafa217f65875314e9a6600c95c"},
-    {file = "tox-3.24.5.tar.gz", hash = "sha256:67e0e32c90e278251fea45b696d0fef3879089ccbe979b0c556d35d5a70e2993"},
+"tox 3.25.0" = [
+    {file = "tox-3.25.0-py2.py3-none-any.whl", hash = "sha256:0805727eb4d6b049de304977dfc9ce315a1938e6619c3ab9f38682bb04662a5a"},
+    {file = "tox-3.25.0.tar.gz", hash = "sha256:37888f3092aa4e9f835fc8cc6dadbaaa0782651c41ef359e3a5743fcb0308160"},
 ]
 "tox-gh-actions 2.8.1" = [
     {file = "tox_gh_actions-2.8.1-py2.py3-none-any.whl", hash = "sha256:9d22215a487f3c2f61ba0af5454010009b23fecf0a909b4a831a20d641a77369"},

--- a/tox.ini
+++ b/tox.ini
@@ -9,19 +9,10 @@ python =
     3.10: py310
 
 [testenv]
-deps=
-    pytest
-    colorama
-    pandas
 commands=
     pytest -s -vv {posargs} {toxinidir}/tests/
 
 [testenv:extra]
-deps=
-    ipython
-    bpython
-    ptpython
-    requests
 changedir={toxinidir}/tests/
 setenv=
     TERM=linux
@@ -32,16 +23,10 @@ commands=
     ipython interactive_test.py
 
 [testenv:lint]
-deps = flake8
 commands = flake8 --ignore=F841,F405,F403,W503 --max-complexity 11 \
            --max-line-length 88 pdir tests
 
 [testenv:mypy]
-deps =
-    pandas
-    pytest>=4.0.0
-    mypy
-    pytest-mypy
 commands = pytest -s --mypy {toxinidir}/tests/ --ignore={toxinidir}/tests/interactive_test.py
 
 [flake8]


### PR DESCRIPTION
PMD doesn't need to download everything again since all of them matches pdm.lock already, the Python3.7 on ubuntu latest only take half the time now: 2m20s before -> 1m now.