### PR TITLE
pdir: Python 3.13

### DIFF
--- a/pdir/attr_category.py
+++ b/pdir/attr_category.py
@@ -101,6 +101,8 @@ ATTR_MAP = {
     '__excepthook__': (AttrCategory.SPECIAL_ATTRIBUTE, AttrCategory.PROPERTY),
     '__mro__': (AttrCategory.SPECIAL_ATTRIBUTE, AttrCategory.PROPERTY),
     '__subclasses__': (AttrCategory.SPECIAL_ATTRIBUTE, AttrCategory.FUNCTION),
+    '__static_attributes__': (AttrCategory.SPECIAL_ATTRIBUTE, AttrCategory.PROPERTY),
+    '__firstlineno__': (AttrCategory.SPECIAL_ATTRIBUTE, AttrCategory.PROPERTY),
     '__next__': (AttrCategory.ITER, AttrCategory.FUNCTION),
     '__enter__': (AttrCategory.CONTEXT_MANAGER, AttrCategory.FUNCTION),
     '__exit__': (AttrCategory.CONTEXT_MANAGER, AttrCategory.FUNCTION),

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -53,6 +53,8 @@ def test_properties():
             '__doc__',
             '__module__',
             '__weakref__',
+            '__static_attributes__',
+            '__firstlineno__',
         ],
     )
 
@@ -115,6 +117,8 @@ def test_own():
             'derived_instance_variable',
             '__doc__',
             '__module__',
+            '__static_attributes__',
+            '__firstlineno__',
         ],
     )
 

--- a/tests/test_pdir_format.py
+++ b/tests/test_pdir_format.py
@@ -109,8 +109,10 @@ def test_slots(fake_tty):
             (
                 '    \x1b[0;36m__class__\x1b[0m\x1b[1;30m, '
                 '\x1b[0m\x1b[0;36m__doc__\x1b[0m\x1b[1;30m, '
+                '\x1b[0m\x1b[0;36m__firstlineno__\x1b[0m\x1b[1;30m, '
                 '\x1b[0m\x1b[0;36m__module__\x1b[0m\x1b[1;30m, '
-                '\x1b[0m\x1b[0;36m__slots__\x1b[0m'
+                '\x1b[0m\x1b[0;36m__slots__\x1b[0m\x1b[1;30m, '
+                '\x1b[0m\x1b[0;36m__static_attributes__\x1b[0m'
             ),
             '\x1b[0;33mabstract class:\x1b[0m',
             '    \x1b[0;36m__subclasshook__\x1b[0m',

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -29,6 +29,10 @@ def test_search_with_argument(fake_tty):
     result3, result4 = pdir(T).s('Attr'), pdir(T).search('Attr')
     expected = '\n'.join(
         [
+            '\x1b[0;33mspecial attribute:\x1b[0m',
+            (
+                '    \x1b[0;36m__static_attributes__\x1b[0m'
+            ),
             '\x1b[0;33mattribute access:\x1b[0m',
             (
                 '    \x1b[0;36m__delattr__\x1b[0m\x1b[1;30m, '


### PR DESCRIPTION
Adds the new attributes that were added in Python 3.13 to the test cases and the attribute lists.

Perhaps these should live in different categories?

Closes #78.